### PR TITLE
Queries recovered from qids require the fomatted query to be copied 

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -840,6 +840,7 @@ public class WMSController {
             }
         } else {
             SpatialSearchRequestParams requestParams = searchDAO.createSpatialSearchRequestParams();
+            requestParams.setFormattedQuery(request.getFormattedQuery());
             requestParams.setQ(request.getQ());
             requestParams.setQc(request.getQc());
             requestParams.setFq(getFq(request));


### PR DESCRIPTION
across, otherwise additional escapes are added in.