### PR TITLE
issue #126 : Add null check on returns from getCachedCount

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -2070,7 +2070,7 @@ public class WMSController {
                 pointsCount = getCachedCount(false, requestParams, q, pointType, useBbox);
 
                 //use bbox when too many points
-                if (pointsCount == null || pointsCount > wmsCacheMaxLayerPoints) {
+                if (pointsCount != null && pointsCount > wmsCacheMaxLayerPoints) {
                     q += StringUtils.join(origAndBBoxFqs, ",");
 
                     requestParams.setFq(origAndBBoxFqs);

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -2061,7 +2061,7 @@ public class WMSController {
         if (canCache) {
             //count docs
             count = getCachedCount(true, requestParams, q, pointType, useBbox);
-            if (count == 0) {
+            if (count == null || count == 0) {
                 return new WMSTile();
             }
 
@@ -2070,14 +2070,14 @@ public class WMSController {
                 pointsCount = getCachedCount(false, requestParams, q, pointType, useBbox);
 
                 //use bbox when too many points
-                if (pointsCount > wmsCacheMaxLayerPoints) {
+                if (pointsCount == null || pointsCount > wmsCacheMaxLayerPoints) {
                     q += StringUtils.join(origAndBBoxFqs, ",");
 
                     requestParams.setFq(origAndBBoxFqs);
                     count = getCachedCount(true, requestParams, q, pointType, useBbox);
                     requestParams.setFq(originalFqs);
 
-                    if (count == 0) {
+                    if (count == null || count == 0) {
                         return new WMSTile();
                     }
 


### PR DESCRIPTION
Fixes issue #126 by adding null checks on the Integer objects returned from getCachedCount. The NullPointerExceptions resulting from the lack of null checks turned up in the biocache-b3 logs yesterday.