### PR TITLE
issue #141 : Add null check in OccurrenceUtils.getAllVersionsByUuid

### DIFF
--- a/src/main/java/au/org/ala/biocache/util/OccurrenceUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/OccurrenceUtils.java
@@ -36,10 +36,12 @@ public class OccurrenceUtils {
     static public FullRecord[] getAllVersionsByUuid(String uuid, Boolean includeSensitive) {
         FullRecord [] occ = Store.getAllVersionsByUuid(uuid, includeSensitive);
 
-        for (FullRecord fr : occ) {
-            Location loc = fr.getLocation();
-            if (loc != null && "null,null,null,null".equals(loc.getBbox())) {
-                loc.setBbox(null);
+        if (occ != null) {
+            for (FullRecord fr : occ) {
+                Location loc = fr.getLocation();
+                if (loc != null && "null,null,null,null".equals(loc.getBbox())) {
+                    loc.setBbox(null);
+                }
             }
         }
 


### PR DESCRIPTION
Adds a null check to OccurrenceUtils.getAllVersionsByUuid to respond to a NullPointerException found in the biocache-b4 logs.

Fixes #141

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>