### PR TITLE
issue #142 : Fix StringIndexOutOfBoundsException in runSolrQuery

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -2583,7 +2583,11 @@ public class SearchDAOImpl implements SearchDAO {
                         suffix = parts[1];
                     } else {
                         if (parts[0].startsWith("-")) {
-                            prefix = "-" + ClientUtils.escapeQueryChars(parts[0].substring(1));
+                            if (parts[0].length() > 1) {
+                                prefix = "-" + ClientUtils.escapeQueryChars(parts[0].substring(1));
+                            } else {
+                                prefix = "-";
+                            }
                         } else {
                             prefix = ClientUtils.escapeQueryChars(parts[0]);
                         }


### PR DESCRIPTION
Check was being done on the first character and then a substring was being called without a length check.

This fixes #142 by adding a length check before calling substring, and using a constant otherwise.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>