### PR TITLE
Fix #202 : Explicitly initialise RecordWriter implementations after their constructor completes

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -565,47 +565,47 @@ public class SearchDAOImpl implements SearchDAO {
         }
         CSVRecordWriter writer = new CSVRecordWriter(out, header);
         try {
-	        writer.initialise();
-	
-	        boolean addedNullFacet = false;
-	
-	        List<String> guids = new ArrayList<String>();
-	        List<Long> counts = new ArrayList<Long>();
-	
-	        for (FieldResultDTO ff : list) {
-	            //only add null facet once
-	            if (ff.getLabel() == null) addedNullFacet = true;
-	            if (ff.getCount() == 0 || (ff.getLabel() == null && addedNullFacet)) continue;
-	
-	            //process the "species_guid_ facet by looking up the list of guids
-	            if (shouldLookup) {
-	                guids.add(ff.getLabel());
-	                if (includeCount) {
-	                    counts.add(ff.getCount());
-	                }
-	
-	                //Only want to send a sub set of the list so that the URI is not too long for BIE
-	                if (guids.size() == 30) {
-	                    //now get the list of species from the web service TODO may need to move this code
-	                    //handle null values being returned from the service...
-	                    writeTaxonDetailsToStream(guids, counts, includeCount, includeSynonyms, includeLists, writer);
-	                    guids.clear();
-	                    counts.clear();
-	                }
-	            } else {
-	                //default processing of facets
-	                String name = ff.getLabel() != null ? ff.getLabel() : "";
-	                String[] row = includeCount ? new String[]{name, Long.toString(ff.getCount())} : new String[]{name};
-	                writer.write(row);
-	            }
-	        }
-	
-	        if (shouldLookup) {
-	            //now write any guids that remain at the end of the looping
-	            writeTaxonDetailsToStream(guids, counts, includeCount, includeSynonyms, includeLists, writer);
-	        }
+            writer.initialise();
+    
+            boolean addedNullFacet = false;
+    
+            List<String> guids = new ArrayList<String>();
+            List<Long> counts = new ArrayList<Long>();
+    
+            for (FieldResultDTO ff : list) {
+                //only add null facet once
+                if (ff.getLabel() == null) addedNullFacet = true;
+                if (ff.getCount() == 0 || (ff.getLabel() == null && addedNullFacet)) continue;
+    
+                //process the "species_guid_ facet by looking up the list of guids
+                if (shouldLookup) {
+                    guids.add(ff.getLabel());
+                    if (includeCount) {
+                        counts.add(ff.getCount());
+                    }
+    
+                    //Only want to send a sub set of the list so that the URI is not too long for BIE
+                    if (guids.size() == 30) {
+                        //now get the list of species from the web service TODO may need to move this code
+                        //handle null values being returned from the service...
+                        writeTaxonDetailsToStream(guids, counts, includeCount, includeSynonyms, includeLists, writer);
+                        guids.clear();
+                        counts.clear();
+                    }
+                } else {
+                    //default processing of facets
+                    String name = ff.getLabel() != null ? ff.getLabel() : "";
+                    String[] row = includeCount ? new String[]{name, Long.toString(ff.getCount())} : new String[]{name};
+                    writer.write(row);
+                }
+            }
+    
+            if (shouldLookup) {
+                //now write any guids that remain at the end of the looping
+                writeTaxonDetailsToStream(guids, counts, includeCount, includeSynonyms, includeLists, writer);
+            }
         } finally {
-        	writer.finalise();
+            writer.finalise();
         }
     }
 
@@ -781,7 +781,7 @@ public class SearchDAOImpl implements SearchDAO {
 
                 CSVRecordWriter writer = new CSVRecordWriter(new CloseShieldOutputStream(out), header);
                 try {
-                	writer.initialise();
+                    writer.initialise();
                     boolean addedNullFacet = false;
 
                     //PAGE through the facets until we reach the end.
@@ -1199,10 +1199,10 @@ public class SearchDAOImpl implements SearchDAO {
                     }
                 }
 
-				@Override
-				public void initialise() {
-					// No resources to create
-				}
+                @Override
+                public void initialise() {
+                    // No resources to create
+                }
 
                 @Override
                 public boolean finalised() {
@@ -1256,7 +1256,7 @@ public class SearchDAOImpl implements SearchDAO {
             Thread writerThread = new Thread(writerRunnable);
 
             try {
-            	rw.initialise();
+                rw.initialise();
                 writerThread.start();
                 if (rw instanceof ShapeFileRecordWriter) {
                     dd.setHeaderMap(((ShapeFileRecordWriter) rw).getHeaderMappings());
@@ -1382,7 +1382,7 @@ public class SearchDAOImpl implements SearchDAO {
                     }
                     // Don't trigger the timeout interrupt if we don't have to wait again as we are already done at this point
                     if (waitAgain && (System.currentTimeMillis() - start) > downloadMaxTime) {
-                    	logger.error("Download max time was exceeded: downloadMaxTime=" + downloadMaxTime + " duration=" + (System.currentTimeMillis() - start));
+                        logger.error("Download max time was exceeded: downloadMaxTime=" + downloadMaxTime + " duration=" + (System.currentTimeMillis() - start));
                         interruptFound.set(true);
                         break;
                     }
@@ -1438,33 +1438,33 @@ public class SearchDAOImpl implements SearchDAO {
                             // First signal that we are in hard shutdown mode
                             interruptFound.set(true);
                         } finally {
-                        	try {
-	                            // Add the sentinel or clear the queue and try again until it gets onto the queue
-	                            // We are in hard shutdown mode, so only priority is that the queue either
-	                            // gets the sentinel or the thread is interrupted to clean up resources
-	                            while (!queue.offer(sentinel)) {
-	                                queue.clear();
-	                            }
-                        	} finally {
-                        		try {
+                            try {
+                                // Add the sentinel or clear the queue and try again until it gets onto the queue
+                                // We are in hard shutdown mode, so only priority is that the queue either
+                                // gets the sentinel or the thread is interrupted to clean up resources
+                                while (!queue.offer(sentinel)) {
+                                    queue.clear();
+                                }
+                            } finally {
+                                try {
                                     // Interrupt the single writer thread
                                     writerThread.interrupt();
-                        		} finally {
-                        			try {
-		                                // Explicitly call finalise on the RecordWriter as a backup
-		                                // In normal circumstances it is called via the sentinel or the interrupt
-		                                // This will not block if finalise has been called previously in the current three implementations
-		                                rw.finalise();
-                        			} finally {	
-		                                if (rw != null && rw.hasError()) {
-		                                    throw RecordWriterException.newRecordWriterException(dd, downloadParams, true, rw);
-		                                } else {
-		                                    // Flush whatever output was still pending for more deterministic debugging
-		                                    out.flush();
-		                                }
-                        			}
-                        		}
-                        	}
+                                } finally {
+                                    try {
+                                        // Explicitly call finalise on the RecordWriter as a backup
+                                        // In normal circumstances it is called via the sentinel or the interrupt
+                                        // This will not block if finalise has been called previously in the current three implementations
+                                        rw.finalise();
+                                    } finally {    
+                                        if (rw != null && rw.hasError()) {
+                                            throw RecordWriterException.newRecordWriterException(dd, downloadParams, true, rw);
+                                        } else {
+                                            // Flush whatever output was still pending for more deterministic debugging
+                                            out.flush();
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1705,7 +1705,7 @@ public class SearchDAOImpl implements SearchDAO {
                             new ShapeFileRecordWriter(tmpShapefileDir, downloadParams.getFile(), out, (String[]) ArrayUtils.addAll(fields, qaFields)));
 
             try {
-            	rw.initialise();
+                rw.initialise();
                 if (rw instanceof ShapeFileRecordWriter) {
                     dd.setHeaderMap(((ShapeFileRecordWriter) rw).getHeaderMappings());
                 }

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -806,57 +806,57 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                 });
 
                 if (!uidStats.isEmpty()) {
-	                List<LinkedHashMap<String, Object>> entities = restTemplate.postForObject(citationServiceUrl,
-	                        uidStats.keySet(), List.class);
+                    List<LinkedHashMap<String, Object>> entities = restTemplate.postForObject(citationServiceUrl,
+                            uidStats.keySet(), List.class);
                     final int UID=0;
                     final int NAME=1;
                     final int CITATION=3;
                     final int RIGHTS=4;
                     final int LINK=5;
                     final int COUNT=9;
-	                for (Map<String, Object> record : entities) {
-	                    // ensure that the record is not null to prevent NPE on
-	                    // the "get"s
-	                    if (record != null) {
+                    for (Map<String, Object> record : entities) {
+                        // ensure that the record is not null to prevent NPE on
+                        // the "get"s
+                        if (record != null) {
                             Object value = record.get("uid");
                             if(value != null) {
-							    AtomicInteger uidRecordCount = uidStats.get(value);
-		                        String count = Optional.ofNullable(uidRecordCount).orElseGet(() -> new AtomicInteger(0)).toString();
-		                        String[] row = new String[] {
-		                                getOrElse(record, "uid", ""),
-		                                getOrElse(record, "name", ""),
-		                                getOrElse(record, "DOI", ""),
-		                                getOrElse(record, "citation", ""),
-		                                getOrElse(record, "rights", ""),
-		                                getOrElse(record, "link", ""),
-		                                getOrElse(record, "dataGeneralizations", ""),
-		                                getOrElse(record, "informationWithheld", ""),
-		                                getOrElse(record, "downloadLimit", ""),
-		                                count };
-		                        writer.writeNext(row);
+                                AtomicInteger uidRecordCount = uidStats.get(value);
+                                String count = Optional.ofNullable(uidRecordCount).orElseGet(() -> new AtomicInteger(0)).toString();
+                                String[] row = new String[] {
+                                        getOrElse(record, "uid", ""),
+                                        getOrElse(record, "name", ""),
+                                        getOrElse(record, "DOI", ""),
+                                        getOrElse(record, "citation", ""),
+                                        getOrElse(record, "rights", ""),
+                                        getOrElse(record, "link", ""),
+                                        getOrElse(record, "dataGeneralizations", ""),
+                                        getOrElse(record, "informationWithheld", ""),
+                                        getOrElse(record, "downloadLimit", ""),
+                                        count };
+                                writer.writeNext(row);
 
-		                        if (readmeCitations != null) {
-		                            // used in README.txt
-		                            readmeCitations.add(row[CITATION] + " (" + row[RIGHTS] + "). " + row[LINK]);
-		                        }
+                                if (readmeCitations != null) {
+                                    // used in README.txt
+                                    readmeCitations.add(row[CITATION] + " (" + row[RIGHTS] + "). " + row[LINK]);
+                                }
 
-		                        if (datasetMetadata != null ) {
-		                            Map<String,String> dataSet = new HashMap<>();
+                                if (datasetMetadata != null ) {
+                                    Map<String,String> dataSet = new HashMap<>();
 
-		                            dataSet.put("uid", row[UID]);
-		                            dataSet.put("name", row[NAME]);
-		                            dataSet.put("licence", row[RIGHTS]);
-		                            dataSet.put("count", row[COUNT]);
+                                    dataSet.put("uid", row[UID]);
+                                    dataSet.put("name", row[NAME]);
+                                    dataSet.put("licence", row[RIGHTS]);
+                                    dataSet.put("count", row[COUNT]);
 
-		                            datasetMetadata.add(dataSet);
-		                        }
+                                    datasetMetadata.add(dataSet);
+                                }
                             } else {
                                 logger.error("Record did not have a uid attribute: " + record);
                             }
-	                    } else {
-	                        logger.error("A null record was returned from the collectory citation service: " + entities + ", collected stats were: " + uidStats);
-	                    }
-	                }
+                        } else {
+                            logger.error("A null record was returned from the collectory citation service: " + entities + ", collected stats were: " + uidStats);
+                        }
+                    }
                 } else {
                     logger.warn("No collected stats for a download");
                 }
@@ -1314,7 +1314,7 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
         return new Thread() {
             @Override
             public void run() {
-            	boolean showErrorMessage = true;
+                boolean showErrorMessage = true;
                 try {
                     Thread.sleep(5*60*1000);
                     try {
@@ -1332,9 +1332,9 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                     logger.error("Interrupted while waiting to delete failed download: directory before retrying: " + new File(currentDownload.getFileLocation()).getParent() +
                                 ", " + e1.getMessage(), e1);
                 } finally {
-                	if (showErrorMessage) {
+                    if (showErrorMessage) {
                         logger.error("Did not successfully wait for retry download timeout: " + new File(currentDownload.getFileLocation()).getParent());
-                	}
+                    }
                 }
             }
         };

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -535,8 +535,8 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
             } else {
                 requestParams.setFacets(new String[] { "data_resource_uid" });
             }
-            ConcurrentMap<String, AtomicInteger> uidStats = null;
-
+            
+            final ConcurrentMap<String, AtomicInteger> uidStats;
             if (fromIndex) {
                 uidStats = searchDAO.writeResultsFromIndexToStream(requestParams, sp, includeSensitive, dd, limit, parallelExecutor);
             } else {

--- a/src/main/java/au/org/ala/biocache/writer/CSVRecordWriter.java
+++ b/src/main/java/au/org/ala/biocache/writer/CSVRecordWriter.java
@@ -37,9 +37,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class CSVRecordWriter implements RecordWriterError {
     private final static Logger logger = LoggerFactory.getLogger(CSVRecordWriter.class);
 
-    private final CSVWriter csvWriter;
     private final OutputStream outputStream;
-
+    private final char separatorChar;
+    private final char quoteChar;
+    private final char escapeChar;
+    
+    private final AtomicBoolean initialised = new AtomicBoolean(false);
     private final AtomicBoolean finalised = new AtomicBoolean(false);
     private final AtomicBoolean finalisedComplete = new AtomicBoolean(false);
 
@@ -47,17 +50,22 @@ public class CSVRecordWriter implements RecordWriterError {
 
     private final List<Throwable> errors = new ArrayList<>();
     
+    // Resources that are created during initialise because they may cause Exception's
+    private CSVWriter csvWriter;
+    
     public CSVRecordWriter(OutputStream out, String[] header){
         outputStream = out;
-        csvWriter = new CSVWriter(new OutputStreamWriter(new CloseShieldOutputStream(out), StandardCharsets.UTF_8), ',', '"');  
-        csvWriter.writeNext(header);
+        separatorChar = ',';
+        quoteChar = '"';
+        escapeChar = CSVWriter.DEFAULT_ESCAPE_CHARACTER;
         this.header = header;
     }
 
     public CSVRecordWriter(OutputStream out, String[] header, char sep, char esc){
         outputStream = out;
-        csvWriter = new CSVWriter(new OutputStreamWriter(new CloseShieldOutputStream(out), StandardCharsets.UTF_8), sep, '"', esc);
-        csvWriter.writeNext(header);
+        separatorChar = sep;
+        quoteChar = '"';
+        escapeChar = esc;
         this.header = header;
     }
     
@@ -66,26 +74,30 @@ public class CSVRecordWriter implements RecordWriterError {
      */
     @Override
     public void write(String[] record) {
-       csvWriter.writeNext(record);
+        if (!initialised.get()) {
+        	throw new IllegalStateException("Must call initialise method before calling write.");
+        }
+        csvWriter.writeNext(record);
 
-       //mark the end of line
-       if (outputStream instanceof OptionalZipOutputStream) {
-           try {
-               // add record byte length, standard separator byte length and buffer (*2) for occasional record character encoding
-               long length = record.length * "\",\"".getBytes(StandardCharsets.UTF_8).length * 2;
-               for (String s : record) if (s != null) length += s.getBytes(StandardCharsets.UTF_8).length;
-               if (((OptionalZipOutputStream) outputStream).isNewFile(this, length)) {
-                   write(header);
-               }
-           } catch (Exception e) {
-               errors.add(e);
-           }
-       }
+        //mark the end of line
+        if (outputStream instanceof OptionalZipOutputStream) {
+            try {
+                // add record byte length, standard separator byte length and buffer (*2) for occasional record character encoding
+                long length = record.length * "\",\"".getBytes(StandardCharsets.UTF_8).length * 2;
+                for (String s : record) if (s != null) length += s.getBytes(StandardCharsets.UTF_8).length;
+                if (((OptionalZipOutputStream) outputStream).isNewFile(this, length)) {
+                    write(header);
+                }
+            } catch (Exception e) {
+                errors.add(e);
+            }
+        }
     }
 
     @Override
     public boolean hasError() {
-        return csvWriter.checkError();
+        CSVWriter toCheckCsvWriter = csvWriter;
+        return (toCheckCsvWriter != null && toCheckCsvWriter.checkError()) || !errors.isEmpty();
     }
 
     @Override
@@ -96,13 +108,24 @@ public class CSVRecordWriter implements RecordWriterError {
     @Override
     public void flush() {
         try {
-            csvWriter.flush();
+            CSVWriter toFlushCsvWriter = csvWriter;
+            if(toFlushCsvWriter != null) {
+                toFlushCsvWriter.flush();
+            }
         } catch(java.io.IOException e){
             logger.debug(e.getMessage(), e);
             errors.add(e);
         }
     }
 
+	@Override
+	public void initialise() {
+		if (initialised.compareAndSet(false, true)) {
+	        csvWriter = new CSVWriter(new OutputStreamWriter(new CloseShieldOutputStream(outputStream), StandardCharsets.UTF_8), separatorChar, quoteChar, escapeChar);
+			csvWriter.writeNext(header);
+		}
+	}
+	
     @Override
     public void finalise() {
         if (finalised.compareAndSet(false, true)) {
@@ -110,7 +133,10 @@ public class CSVRecordWriter implements RecordWriterError {
                 flush();
             } finally {
                 try {
-                    csvWriter.close();
+                    CSVWriter toCloseCsvWriter = csvWriter;
+					if(toCloseCsvWriter != null) {
+						toCloseCsvWriter.close();
+					}
                 } catch (IOException e) {
                     errors.add(e);
 		        } finally {
@@ -124,4 +150,10 @@ public class CSVRecordWriter implements RecordWriterError {
     public boolean finalised() {
         return finalisedComplete.get();
     }
+
+	@Override
+	public void close() throws IOException {
+		finalise();
+	}
+
 }

--- a/src/main/java/au/org/ala/biocache/writer/RecordWriterError.java
+++ b/src/main/java/au/org/ala/biocache/writer/RecordWriterError.java
@@ -14,6 +14,7 @@
  ***************************************************************************/
 package au.org.ala.biocache.writer;
 
+import java.io.Closeable;
 import java.util.List;
 
 import au.org.ala.biocache.RecordWriter;
@@ -21,7 +22,7 @@ import au.org.ala.biocache.RecordWriter;
 /**
  * Method for catching RecordWriter errors
  */
-public interface RecordWriterError extends RecordWriter {
+public interface RecordWriterError extends RecordWriter, Closeable {
 
     /**
      * @return true when there is a write error

--- a/src/main/java/au/org/ala/biocache/writer/ShapeFileRecordWriter.java
+++ b/src/main/java/au/org/ala/biocache/writer/ShapeFileRecordWriter.java
@@ -83,6 +83,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
     private final OutputStream outputStream;
     private final ListFeatureCollection collection;
     private final Map<String, String> headerMappings;
+    private final String[] originalHeader;
 
     private final AtomicBoolean initialised = new AtomicBoolean(false);
     private final AtomicBoolean finalised = new AtomicBoolean(false);
@@ -93,7 +94,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
 
     private final int latIdx, longIdx;
 
-    // Resources that are created during initialise because they may cause Exception's
+    // Resources that are created during initialise because their creation sequence may include Exception's
     private volatile Transaction transaction;
     private volatile File temporaryShapeFile;
     private volatile ShapefileDataStore newDataStore;
@@ -104,6 +105,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
     public ShapeFileRecordWriter(String tmpdir, String filename, OutputStream out, String[] header) {
         tmpDownloadDirectory = tmpdir;
         tmpFilename = filename;
+        originalHeader = header;
         //perform the header mappings so that features are only 10 characters long.
         headerMappings = AlaFileUtils.generateShapeHeader(header);
         //set the outputStream
@@ -121,12 +123,6 @@ public class ShapeFileRecordWriter implements RecordWriterError {
         featureBuilder = new SimpleFeatureBuilder(simpleFeature);
 
         collection = new ListFeatureCollection(featureBuilder.getFeatureType());
-
-        if (latIdx < 0 || longIdx < 0) {
-            logger.error("The invalid header..." + StringUtils.join(header, "|"));
-            throw new IllegalArgumentException("A Shape File Export needs to include latitude and longitude in the headers: " + StringUtils.join(header, "|"));
-        }
-
     }
 
     /**
@@ -164,45 +160,50 @@ public class ShapeFileRecordWriter implements RecordWriterError {
         return LOCATION;
     }
 
-	@Override
-	public void initialise() {
-		if(initialised.compareAndSet(false, true)) {
-	        try {
-	            //initialise a temporary file that can used to write the shape file
-	            temporaryShapeFile = new File(tmpDownloadDirectory + File.separator + System.currentTimeMillis() + File.separator + tmpFilename + File.separator + tmpFilename + ".shp");
-	                FileUtils.forceMkdir(temporaryShapeFile.getParentFile());
-	            Map<String, Serializable> params = new HashMap<String, Serializable>();
-	            params.put("url", temporaryShapeFile.toURI().toURL());
-	            params.put("create spatial index", Boolean.TRUE);
-	
-	            transaction = new DefaultTransaction("create");
-	            newDataStore = (ShapefileDataStore) dataStoreFactory.createNewDataStore(params);
-	            newDataStore.createSchema(simpleFeature);
-	            typeName = newDataStore.getTypeNames()[0];
-	            featureSource = newDataStore.getFeatureSource(typeName);
-	
-	            if (featureSource instanceof SimpleFeatureStore) {
-	                featureStore = (SimpleFeatureStore) featureSource;
-	                featureStore.setTransaction(transaction);
-	            } else {
-	                writerError.set(true);
-	                logger.error(typeName + " is not currently supported for read/write access");
-	            }
-	
-	            //lat,lng csv header
-	            // FIXME: What relevant does OptionalZipOutputStream have to whether the CSV header line is written?
-	            if (outputStream instanceof OptionalZipOutputStream) {
-	                outputStream.write(("latitude,longitude\n").getBytes(StandardCharsets.UTF_8));
-	            }
-	
-	        } catch (java.io.IOException e) {
-	            logger.error("Unable to create ShapeFile", e);
-	            writerError.set(true);
-	            errors.add(e);
-	        }
-		}
-	}
-	
+    @Override
+    public void initialise() {
+        if(initialised.compareAndSet(false, true)) {
+            try {
+                if (latIdx < 0 || longIdx < 0) {
+                    logger.error("The invalid header..." + StringUtils.join(originalHeader, "|"));
+                    throw new IllegalArgumentException("A Shape File Export needs to include latitude and longitude in the headers: " + StringUtils.join(originalHeader, "|"));
+                }
+
+                //initialise a temporary file that can used to write the shape file
+                temporaryShapeFile = new File(tmpDownloadDirectory + File.separator + System.currentTimeMillis() + File.separator + tmpFilename + File.separator + tmpFilename + ".shp");
+                    FileUtils.forceMkdir(temporaryShapeFile.getParentFile());
+                Map<String, Serializable> params = new HashMap<String, Serializable>();
+                params.put("url", temporaryShapeFile.toURI().toURL());
+                params.put("create spatial index", Boolean.TRUE);
+    
+                transaction = new DefaultTransaction("create");
+                newDataStore = (ShapefileDataStore) dataStoreFactory.createNewDataStore(params);
+                newDataStore.createSchema(simpleFeature);
+                typeName = newDataStore.getTypeNames()[0];
+                featureSource = newDataStore.getFeatureSource(typeName);
+    
+                if (featureSource instanceof SimpleFeatureStore) {
+                    featureStore = (SimpleFeatureStore) featureSource;
+                    featureStore.setTransaction(transaction);
+                } else {
+                    writerError.set(true);
+                    logger.error(typeName + " is not currently supported for read/write access");
+                }
+    
+                //lat,lng csv header
+                // FIXME: What relevant does OptionalZipOutputStream have to whether the CSV header line is written?
+                if (outputStream instanceof OptionalZipOutputStream) {
+                    outputStream.write(("latitude,longitude\n").getBytes(StandardCharsets.UTF_8));
+                }
+    
+            } catch (java.io.IOException e) {
+                logger.error("Unable to create ShapeFile", e);
+                writerError.set(true);
+                errors.add(e);
+            }
+        }
+    }
+    
     /**
      * Indicates that the download has completed and the shape file should be generated and
      * written to the supplied output stream.
@@ -215,42 +216,42 @@ public class ShapeFileRecordWriter implements RecordWriterError {
                     //write & clear the current batch
                     if (!collection.isEmpty()) {
                         SimpleFeatureStore toAddFeatureStore = featureStore;
-						if (toAddFeatureStore != null) {
+                        if (toAddFeatureStore != null) {
                             toAddFeatureStore.addFeatures(collection);
                         }
                         collection.clear();
                     }
                 } finally {
                     try {
-                    	// Dereference the non-final field to ensure we don't have another thread setting it between the null check and the commit call
-                    	Transaction toCommitTransaction = transaction;
-                    	if (toCommitTransaction != null) {
-                    		toCommitTransaction.commit();
-                    	}
+                        // Dereference the non-final field to ensure we don't have another thread setting it between the null check and the commit call
+                        Transaction toCommitTransaction = transaction;
+                        if (toCommitTransaction != null) {
+                            toCommitTransaction.commit();
+                        }
                     } finally {
                         try {
-                        	Transaction toCloseTransaction = transaction;
-                        	if (toCloseTransaction != null) {
-                        		toCloseTransaction.close();
-                        	}
+                            Transaction toCloseTransaction = transaction;
+                            if (toCloseTransaction != null) {
+                                toCloseTransaction.close();
+                            }
                         } finally {
                             try {
                                 ShapefileDataStore toCloseDataStore = newDataStore;
-								if(toCloseDataStore != null) {
+                                if(toCloseDataStore != null) {
                                     toCloseDataStore.dispose();
                                 }
                             } finally {
                                 try {
                                     // Allow for future cases where this isn't equivalent to the statements above
                                     SimpleFeatureStore toDisposeFeatureStore = featureStore;
-									if (toDisposeFeatureStore != null) {
+                                    if (toDisposeFeatureStore != null) {
                                         toDisposeFeatureStore.getDataStore().dispose();
                                     }
                                 } finally {
                                     try {
                                         // Allow for future cases where this isn't equivalent to the statements above
                                         SimpleFeatureSource toDisposeFeatureSource = featureSource;
-										if (toDisposeFeatureSource != null) {
+                                        if (toDisposeFeatureSource != null) {
                                             toDisposeFeatureSource.getDataStore().dispose();
                                         }
                                     } finally {
@@ -269,7 +270,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
                                             }
 
                                             File toCopyTemporaryShapeFile = temporaryShapeFile;
-											if (toCopyTemporaryShapeFile != null) {
+                                            if (toCopyTemporaryShapeFile != null) {
                                                 //zip the parent directory
                                                 String targetZipFile = toCopyTemporaryShapeFile.getParentFile().getParent() + File.separator + toCopyTemporaryShapeFile.getName().replace(".shp", ".zip");
                                                 AlaFileUtils.createZip(toCopyTemporaryShapeFile.getParent(), targetZipFile);
@@ -282,7 +283,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
                                             }
                                         } finally {
                                             File toDeleteTemporaryShapeFile = temporaryShapeFile;
-											if (toDeleteTemporaryShapeFile != null) {
+                                            if (toDeleteTemporaryShapeFile != null) {
                                                 //now remove the temporary directory
                                                 FileUtils.deleteDirectory(toDeleteTemporaryShapeFile.getParentFile().getParentFile());
                                             }
@@ -309,7 +310,7 @@ public class ShapeFileRecordWriter implements RecordWriterError {
     @Override
     public void write(String[] record) {
         if (!initialised.get()) {
-        	throw new IllegalStateException("Must call initialise method before calling write.");
+            throw new IllegalStateException("Must call initialise method before calling write.");
         }
         //check to see if there are values for latitudes and longitudes
         if (StringUtils.isNotBlank(record[longIdx]) && StringUtils.isNotBlank(record[latIdx])) {
@@ -391,9 +392,9 @@ public class ShapeFileRecordWriter implements RecordWriterError {
         }
     }
 
-	@Override
-	public void close() throws IOException {
-		finalise();
-	}
+    @Override
+    public void close() throws IOException {
+        finalise();
+    }
 
 }

--- a/src/main/java/au/org/ala/biocache/writer/TSVRecordWriter.java
+++ b/src/main/java/au/org/ala/biocache/writer/TSVRecordWriter.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 
- * A Writer that outputs a record in CSV format
+ * A Writer that outputs a record in TSV format
  * 
  * @author Natasha Carter
  */
@@ -56,7 +56,7 @@ public class TSVRecordWriter implements RecordWriterError {
     @Override
     public void write(String[] record) {
         if (!initialised.get()) {
-        	throw new IllegalStateException("Must call initialise method before calling write.");
+            throw new IllegalStateException("Must call initialise method before calling write.");
         }
         StringBuilder line = new StringBuilder(256);
 
@@ -86,12 +86,12 @@ public class TSVRecordWriter implements RecordWriterError {
         }
     }
 
-	@Override
-	public void initialise() {
-		if (initialised.compareAndSet(false, true)) {
-			write(header);
-		}
-	}
+    @Override
+    public void initialise() {
+        if (initialised.compareAndSet(false, true)) {
+            write(header);
+        }
+    }
 
     @Override
     public void finalise() {
@@ -130,8 +130,8 @@ public class TSVRecordWriter implements RecordWriterError {
     }
 
     @Override
-	public void close() throws IOException {
-		finalise();
-	}
+    public void close() throws IOException {
+        finalise();
+    }
 
 }


### PR DESCRIPTION
Explicitly ``initialise`` ``RecordWriter`` implementations after their constructor completes so we always have a ``RecordWriter`` object reference available to call ``finalise`` on. In the case of #202, this will ensure that we have the best chance of explicitly calling back into GeoTools to close the ``Transaction`` we open when we create/initialise a ``ShapeFileRecordWriter``.

This also fixes cases where ``finalise`` was not called consistently from within a dedicated ``finally`` block, which could also have triggered the same behaviour.

This also adds ``java.io.Closeable`` to ``RecordWriterError`` so that standard static bug checkers in future can be used to identify when we are not consistently closing objects, but does not yet switch from ``finalise`` to ``close`` or ``try-with-resources``. Java-10 adds the ability to put already created resources into ``try-with-resources``, so when we get to that stage we will be able to use it directly.

Although I didn't replicate the error message, this fixes cases that could be identified as potential sources of the error just based on visual analysis of the code to reduce the likelihood of it occurring again. Given the size of the in-memory representations of some of the Shapefiles that people create using the download service (multi-gigabyte), this could prevent very large memory leaks when Solr goes down, for instance, and the record writer terminates early.