### PR TITLE
issue #377 : Add ampersand between OGC and query parameters

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -1648,8 +1648,14 @@ public class WMSController extends AbstractSecureController{
                 + "&WIDTH=" + width + "&HEIGHT=" + height
                 + "&OUTLINE=" + outlinePoints + "&OUTLINECOLOUR=" + outlineColour;
 
-        //get query parameters
-        speciesAddress += requestParams.toString();
+        String serialisedQueryParameters = requestParams.toString();
+
+        if (!serialisedQueryParameters.isEmpty()) {
+            speciesAddress += "&";
+        }
+
+        // add query parameters
+        speciesAddress += serialisedQueryParameters;
 
         URL speciesURL = new URL(speciesAddress);
         BufferedImage speciesImage = ImageIO.read(speciesURL);


### PR DESCRIPTION
Naive attempt at fixing #377 based on inspection of the URL that was failing due to a missing ampersand.