### PR TITLE
Added a new structure for applied filters

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -708,7 +708,8 @@ public class SearchDAOImpl implements SearchDAO {
         SpatialSearchRequestParams original = new SpatialSearchRequestParams();
         BeanUtils.copyProperties(searchParams, original);
         try {
-            Map<String, Facet> activeFacetMap = queryFormatUtils.formatSearchQuery(searchParams, true);
+            Map[] fqMaps = queryFormatUtils.formatSearchQuery(searchParams, true);
+
             String queryString = searchParams.getFormattedQuery();
             SolrQuery solrQuery = initSolrQuery(searchParams, true, extraParams); // general search settings
             solrQuery.setQuery(queryString);
@@ -721,7 +722,8 @@ public class SearchDAOImpl implements SearchDAO {
             searchResults.setUrlParameters(original.getUrlParams());
 
             //now update the fq display map...
-            searchResults.setActiveFacetMap(activeFacetMap);
+            searchResults.setActiveFacetMap(fqMaps[0]);
+            searchResults.setActiveFacetObj(fqMaps[1]);
 
             if (logger.isInfoEnabled()) {
                 logger.info("spatial search query: " + queryString);

--- a/src/main/java/au/org/ala/biocache/dto/SearchResultDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/SearchResultDTO.java
@@ -60,7 +60,12 @@ public class SearchResultDTO {
      * Stores a map a facets that have been applied to the query.  This will include details that a
      * necessary to display on clients.
      */
-    private Map<String,Facet> activeFacetMap;
+    private Map<String, Facet> activeFacetMap;
+    /*
+     * Stores a map of facets that have been applied to the query. Since multiple fqs can be applied on same field
+     * like &fq=-month:"11"&fq=-month:"12", current implementation in activeFacetMap can't handle this.
+     */
+    private Map<String, List<Facet>> activeFacetObj;
 
     /**
      * Constructor with 2 args
@@ -212,4 +217,17 @@ public class SearchResultDTO {
         this.activeFacetMap = activeFacetMap;
     }
 
+    /**
+     * @return the activeFacetObj
+     */
+    public Map<String, List<Facet>> getActiveFacetObj() {
+        return activeFacetObj;
+    }
+
+    /**
+     * @param activeFacetObj the activeFacetObj to set
+     */
+    public void setActiveFacetObj(Map<String, List<Facet>> activeFacetObj) {
+        this.activeFacetObj = activeFacetObj;
+    }
 }


### PR DESCRIPTION
Existing activeFacetMap doesn't handle case where multiple fqs have same filter for example &fq=-month:'11'&fq=-month:'12'.

A new structure activeFacetObj was added to hold [Key: List<Facet>]

Also a bug in formatting displayname is also fixed.