### PR TITLE
format fq doesn't work for fqs start with "-("

### DIFF
--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -809,7 +809,10 @@ public class QueryFormatUtils {
                 } else {
                     MatchResult mr = m.toMatchResult();
 
-                    if (matchedIndexTerm.startsWith("-")) {
+                    if (matchedIndexTerm.startsWith("-(")) {
+                        matchedIndexTerm = matchedIndexTerm.substring(2);
+                        formatted += "-(";
+                    } else if (matchedIndexTerm.startsWith("-")) {
                         matchedIndexTerm = matchedIndexTerm.substring(1);
                         formatted += "-";
                     }


### PR DESCRIPTION
For fq=-(month:"02") or fq=-(month:"02" OR month:"03") '02' is not translated to 'Februray'

Below is current query result.
```
    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(month:\"02\")",
            "value": "\"02\")"
        }
    }

    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(month:\"02\" OR Month:\"March\")",
            "value": "\"02\" OR month:\"03\")"
        }
    }
```

With changes in this PR

```
    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(Month:\"February\")",
            "value": "\"02\")"
        }
    }

    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(Month:\"February\" OR Month:\"March\")",
            "value": "\"02\" OR month:\"03\")"
        }
    }
```

