### PR TITLE
format fq doesn't work for fqs start with "-("

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>au.org.ala</groupId>
     <artifactId>biocache-service</artifactId>
     <packaging>war</packaging>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
     <name>biocache-service</name>
     <url>https://biocache-ws.ala.org.au/ws</url>
     <description>This is a the service layer for the Biocache.

--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -809,7 +809,10 @@ public class QueryFormatUtils {
                 } else {
                     MatchResult mr = m.toMatchResult();
 
-                    if (matchedIndexTerm.startsWith("-")) {
+                    if (matchedIndexTerm.startsWith("-(")) {
+                        matchedIndexTerm = matchedIndexTerm.substring(2);
+                        formatted += "-(";
+                    } else if (matchedIndexTerm.startsWith("-")) {
                         matchedIndexTerm = matchedIndexTerm.substring(1);
                         formatted += "-";
                     }

--- a/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
@@ -151,4 +151,24 @@ public class FilterQueryParserTest {
         assertTrue("got: " + month.getValue(), StringUtils.containsIgnoreCase(month.getValue(), "09 OR month:10 OR month:11"));
         assertTrue("got: " + month.getDisplayName(), StringUtils.containsIgnoreCase(month.getDisplayName(), "Month:September OR Month:October OR Month:November"));
     }
+
+    @Test
+    public void testFqFormat() {
+        SpatialSearchRequestParams query = new SpatialSearchRequestParams();
+        String[][] fqs = new String[][] {
+                {"-month:\"09\"", "-Month:\"September\""},
+                {"-(month:\"09\")", "-(Month:\"September\")"},
+                {"-(month:\"09\" OR month:\"10\")", "-(Month:\"September\" OR Month:\"October\")"},
+                {"month:\"09\"", "Month:\"September\""},
+                {"(month:\"09\")", "(Month:\"September\")"},
+                {"month:\"09\" OR month:\"10\"", "Month:\"September\" OR Month:\"October\""},
+                {"(month:\"09\" OR month:\"10\")", "(Month:\"September\" OR Month:\"October\")"}};
+
+        for (String[] fq : fqs) {
+            query.setFq(new String[] { fq[0] });
+            Map<String, Facet> facetMap = queryFormatUtils.formatSearchQuery(query, true);
+            assertTrue(facetMap != null && facetMap.size() == 1);
+            assertTrue(facetMap.get(facetMap.keySet().iterator().next()).getDisplayName().equals(fq[1]));
+        }
+    }
 }


### PR DESCRIPTION
For fq=-(month:"02") or fq=-(month:"02" OR month:"03") '02' is not translated to 'Februray'

Below is current query result.
```
    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(month:\"02\")",
            "value": "\"02\")"
        }
    }

    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(month:\"02\" OR Month:\"March\")",
            "value": "\"02\" OR month:\"03\")"
        }
    }
```

With changes in this PR

```
    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(Month:\"February\")",
            "value": "\"02\")"
        }
    }

    "activeFacetMap": {
        "-(month": {
            "name": "-(month",
            "displayName": "-(Month:\"February\" OR Month:\"March\")",
            "value": "\"02\" OR month:\"03\")"
        }
    }
```

Ref #434 