### PR TITLE
Tomcat 8.5+9 update

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context antiJARLocking="true" path="/biocache-service">
-<!-- 
+<Context path="/biocache-service">
+<!--
     TOMCAT SPECIFIC 
     NC 20130808: Use a virtual webapp loader to provide external directory where it will look for resources first,
     thus allowing biocache.properties to be configured external to tomcat 
  -->
-<Loader className="org.apache.catalina.loader.VirtualWebappLoader" virtualClasspath="/data/biocache/config" searchVirtualFirst="true"/>
+    <Resources className="org.apache.catalina.webresources.StandardRoot">
+        <PreResources className="org.apache.catalina.webresources.DirResourceSet"
+                      base="/data/biocache/config"
+                      internalPath="/"
+                      webAppMount="/WEB-INF/classes" />
+    </Resources>
 </Context>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -98,4 +98,16 @@
         <filter-name>CorsFilter</filter-name>
         <url-pattern>*</url-pattern>
     </filter-mapping>
+
+    <!-- tld -->
+    <jsp-config>
+        <taglib>
+            <taglib-uri>/tld/ala.tld</taglib-uri>
+            <taglib-location>/tld/ala.tld</taglib-location>
+        </taglib>
+        <taglib>
+            <taglib-uri>/tld/json.tld</taglib-uri>
+            <taglib-location>/tld/json.tld</taglib-location>
+        </taglib>
+    </jsp-config>
 </web-app>


### PR DESCRIPTION
updated context.xml to support deployment to tomcat 8.5 / 9

I've confirmed deployment of war on:
 - tomcat 8.5.54
 - tomcat 9.0.34 

@djtfmartin could you please confirm if there is and ramifications of removing antiJarLocking? It does not seem to be required but I don't understand the reason it was enabled originally. 