### PR TITLE
issue #456 Add doi.txt file to download ZIP

### DIFF
--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -746,6 +746,15 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                         + dataFieldDescriptionURL + "'>Download Fields</a>.").getBytes(StandardCharsets.UTF_8));
                 sp.closeEntry();
 
+                if (mintDoi && doiResponse != null) {
+
+                    sp.putNextEntry("doi.txt");
+
+                    sp.write((OFFICIAL_DOI_RESOLVER + doiResponse.getDoi()).getBytes(StandardCharsets.UTF_8));
+                    sp.write(CSVWriter.DEFAULT_LINE_END.getBytes(StandardCharsets.UTF_8));
+                    sp.closeEntry();
+                }
+
                 // Add headings file, listing information about the headings
                 if (headingsEnabled) {
                     // add the citations for the supplied uids


### PR DESCRIPTION
I've added a new `doi.txt` to the download zip file containing the DOI reference. The file is only added if `mintDoi=true` as per AtlasOfLivingAustralia/ALA4R#60

Note: This issue has been difficult to test in dev due to dependencies with external services. 