### PR TITLE
feature #376 expose app.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,12 @@
     </dependencies>
     <build>
         <finalName>biocache-service</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <!-- The gmavenplus plugin is used to compile Groovy code. To learn more about this plugin,
@@ -542,6 +548,20 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/au/org/ala/biocache/web/BuildInfoController.java
+++ b/src/main/java/au/org/ala/biocache/web/BuildInfoController.java
@@ -1,0 +1,57 @@
+package au.org.ala.biocache.web;
+
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+@Controller
+class BuildInfoController {
+
+    private final static Logger logger = Logger.getLogger(BuildInfoController.class);
+
+    @RequestMapping(value="/buildInfo", method = RequestMethod.GET)
+    public void buildInfo(Model model) {
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        try (
+                InputStream buildInfoStream = classLoader.getResourceAsStream("/buildInfo.properties");
+                InputStream runtimeEnvironmentStream = classLoader.getResourceAsStream("/runtimeEnvironment.properties");
+            ) {
+
+            if (runtimeEnvironmentStream != null) {
+
+                try {
+                    Properties runtimeEnvironmentProperties = new Properties();
+                    runtimeEnvironmentProperties.load(runtimeEnvironmentStream);
+                    runtimeEnvironmentProperties.setProperty("java.version", System.getProperty("java.version"));
+                    model.addAttribute("runtimeEnvironment", runtimeEnvironmentProperties);
+                } catch (IOException e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+
+            if (buildInfoStream != null) {
+
+                try {
+                    Properties buildInfoProperties = new Properties();
+                    buildInfoProperties.load(buildInfoStream);
+                    model.addAttribute("buildInfo", buildInfoProperties);
+                } catch (IOException e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/au/org/ala/biocache/web/BuildInfoController.java
+++ b/src/main/java/au/org/ala/biocache/web/BuildInfoController.java
@@ -35,7 +35,7 @@ class BuildInfoController {
                     runtimeEnvironmentProperties.setProperty("java.version", System.getProperty("java.version"));
                     model.addAttribute("runtimeEnvironment", runtimeEnvironmentProperties);
                 } catch (IOException e) {
-                    logger.error(e.getMessage(), e);
+                    logger.error("failed to read 'runtimeEnvironment.properties' resource", e);
                 }
             }
 
@@ -46,7 +46,7 @@ class BuildInfoController {
                     buildInfoProperties.load(buildInfoStream);
                     model.addAttribute("buildInfo", buildInfoProperties);
                 } catch (IOException e) {
-                    logger.error(e.getMessage(), e);
+                    logger.error("failed to read 'buildInfo.properties' resource", e);
                 }
             }
 

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -228,7 +228,7 @@ public class OccurrenceController extends AbstractSecureController {
                 model.addAttribute("versionInfoString", sb.toString());
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                logger.error("failed to read 'git.properties' resource", e);
             }
         }
         return HOME;
@@ -1120,7 +1120,7 @@ public class OccurrenceController extends AbstractSecureController {
             return null;
         }
         if(apiKey != null){
-            occurrenceSensitiveDownload(requestParams, apiKey, true, zip, response, request);
+                occurrenceSensitiveDownload(requestParams, apiKey, true, zip, response, request);
             return null;
         }
         try {

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -1120,7 +1120,7 @@ public class OccurrenceController extends AbstractSecureController {
             return null;
         }
         if(apiKey != null){
-                occurrenceSensitiveDownload(requestParams, apiKey, true, zip, response, request);
+            occurrenceSensitiveDownload(requestParams, apiKey, true, zip, response, request);
             return null;
         }
         try {

--- a/src/main/resources/buildInfo.properties
+++ b/src/main/resources/buildInfo.properties
@@ -1,0 +1,6 @@
+git.commit.date=${git.commit.time}
+git.commit.id=${git.commit.id}
+git.commit.shortId=${git.commit.id.abbrev}
+git.branch=${git.branch}
+git.closest.tag.name=${git.closest.tag.name}
+git.closest.tag.commit.count=${git.closest.tag.commit.count}

--- a/src/main/resources/runtimeEnvironment.properties
+++ b/src/main/resources/runtimeEnvironment.properties
@@ -1,0 +1,4 @@
+app.buildTime=${maven.build.timestamp}
+app.version=${project.version}
+app.spring.version=${spring.version}
+build.java.version=${java.version}

--- a/src/main/webapp/WEB-INF/decorators/main.jsp
+++ b/src/main/webapp/WEB-INF/decorators/main.jsp
@@ -51,6 +51,8 @@
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <decorator:head />
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/jsp/buildInfo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/buildInfo.jsp
@@ -1,0 +1,76 @@
+<%@ page contentType="text/html" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="pageName" content="home"/>
+    <title>Build Info</title>
+    <style type="text/css">
+        h1 {
+            /*color: #48802c;*/
+            font-weight: normal;
+            font-size: 24px;
+            margin: .8em 0 .3em 0;
+        }
+
+        table {
+            border: 1px solid #ccc;
+            font-size: 14px;
+        }
+
+        tr {
+            border: 0;
+        }
+
+        td, th {
+            padding: 5px 6px;
+            text-align: left;
+            vertical-align: top;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>Build Info</h1>
+
+    <table>
+        <tr>
+            <td>Git commit date/time</td><td>${buildInfo.getProperty('git.commit.date')}</td>
+        </tr>
+        <tr>
+            <td>Git commit ID</td><td>${buildInfo.getProperty('git.commit.id')}</td>
+        </tr>
+        <tr>
+            <td>Git commit short ID</td><td>${buildInfo.getProperty('git.commit.shortId')}</td>
+        </tr>
+        <tr>
+            <td>Git branch</td><td>${buildInfo.getProperty('git.branch')}</td>
+        </tr>
+        <tr>
+            <td>Git closest tag name</td><td>${buildInfo.getProperty('git.closest.tag.name')}</td>
+        </tr>
+        <tr>
+            <td>Git closest tag commit count</td><td>${buildInfo.getProperty('git.closest.tag.commit.count')}</td>
+        </tr>
+    </table>
+
+    <h1>Runtime Application Status</h1>
+
+    <table>
+        <tr>
+            <td>App version</td><td>${runtimeEnvironment.getProperty('app.version')}</td>
+        </tr>
+        <tr>
+            <td>App build timestamp</td><td>${runtimeEnvironment.getProperty('app.buildTime')}</td>
+        </tr>
+        <tr>
+            <td>Spring version</td><td>${runtimeEnvironment.getProperty('app.spring.version')}</td>
+        </tr>
+        <tr>
+            <td>JVM Version</td><td>${runtimeEnvironment.getProperty('java.version')}</td>
+        </tr>
+    </table>
+
+</body>
+</html>


### PR DESCRIPTION
I have written a new `BuildInfoController` and view that mimics [ala-admin-plugin/BuildInfoController.groovy](https://github.com/AtlasOfLivingAustralia/ala-admin-plugin/blob/master/grails-app/controllers/au/org/ala/admin/BuildInfoController.groovy).
Build and runtime properties are injected via maven `git-commit-id-plugin` plugin.

The build info can be access at `/ws/buildInfo` for html view or `/ws/buildInfo.json` for JSON output.

<img width="1256" alt="Screen Shot 2020-06-25 at 2 44 11 pm" src="https://user-images.githubusercontent.com/12233783/85655253-9a94b800-b6f2-11ea-874a-23360102673a.png">
<img width="1236" alt="Screen Shot 2020-06-25 at 2 50 06 pm" src="https://user-images.githubusercontent.com/12233783/85655694-2eff1a80-b6f3-11ea-9bd2-e93720f68b67.png">
