### PR TITLE
#55 Download status updates

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -216,7 +216,7 @@ public class DownloadController extends AbstractSecureController {
             status.put("message", "Already in queue.");
             status.put("status", "inQueue");
             status.put("queueSize", persistentQueueDAO.getTotalDownloads());
-            status.put("statusUrl", downloadService.webservicesRoot + "/occurrences/offline/status/" + dd.getUniqueId());
+            status.put("statusUrl", downloadService.webservicesRoot + "/occurrences/offline/status/" + d.getUniqueId());
         } else if (dd.getTotalRecords() > downloadService.dowloadOfflineMaxSize) {
             //identify this download as too large
             File file = new File(downloadService.biocacheDownloadDir + File.separator + UUID.nameUUIDFromBytes(dd.getEmail().getBytes(StandardCharsets.UTF_8)) + File.separator + dd.getStartTime() + File.separator + "tooLarge");


### PR DESCRIPTION
When a user re-execute the same download (same email/params) which still pending, we will return the initial statusUrl 

Before, we returned the new statusUrl (with the new downloadID) which redirected to a failed status.
Now, we returned to the initial statusUrl so the download confirm popup is successful.