### PR TITLE
bumped parent pom to v13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>au.org.ala</groupId>
         <artifactId>ala-parent-pom</artifactId>
-        <version>12</version>
+        <version>13</version>
     </parent>
 
     <groupId>au.org.ala</groupId>


### PR DESCRIPTION
incorporate fix the updates to the ala-parent-pom v13 which will reinstate the automated junit4 tests. 