### PR TITLE
added a new filed into indexFieldDTO

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -3521,7 +3521,7 @@ public class SearchDAOImpl implements SearchDAO {
                 //7. i18nValues: true | false, indicates that the values returned by this field can be
                 //   translated using facetName.value= in /facets/i18n
                 //8. class value for this field
-                //9. furtherInfo: wiki link from wiki.fieldName= in i18n
+                //9. infoUrl: wiki link from wiki.fieldName= in i18n
                 if (layersPattern.matcher(fieldName).matches()) {
                     f.setDownloadName(fieldName);
                     String description = layersService.getLayerNameMap().get(fieldName);
@@ -3668,7 +3668,7 @@ public class SearchDAOImpl implements SearchDAO {
                     //(9) has wiki link in i18n
                     String wikiLink = messageSource.getMessage("wiki." + fieldName, null, "", Locale.getDefault());
                     if (wikiLink.length() > 0) {
-                        f.setFurtherInfo(wikiLink);
+                        f.setInfoUrl(wikiLink);
                     }
 
                 }

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -3521,6 +3521,7 @@ public class SearchDAOImpl implements SearchDAO {
                 //7. i18nValues: true | false, indicates that the values returned by this field can be
                 //   translated using facetName.value= in /facets/i18n
                 //8. class value for this field
+                //9. furtherInfo: wiki link from wiki.fieldName= in i18n
                 if (layersPattern.matcher(fieldName).matches()) {
                     f.setDownloadName(fieldName);
                     String description = layersService.getLayerNameMap().get(fieldName);
@@ -3663,6 +3664,13 @@ public class SearchDAOImpl implements SearchDAO {
                     if (classs.length() > 0) {
                         f.setClasss(classs);
                     }
+
+                    //(9) has wiki link in i18n
+                    String wikiLink = messageSource.getMessage("wiki." + fieldName, null, "", Locale.getDefault());
+                    if (wikiLink.length() > 0) {
+                        f.setFurtherInfo(wikiLink);
+                    }
+
                 }
 
 

--- a/src/main/java/au/org/ala/biocache/dto/IndexFieldDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/IndexFieldDTO.java
@@ -42,6 +42,8 @@ public class IndexFieldDTO implements Comparable<IndexFieldDTO> {
     private String description;
     /** the i18n information used for this field */
     private String info;
+    /** furtherInfo for this field*/
+    private String furtherInfo;
     /** the occurrences/search json key for this field */
     private String jsonName;
     /** the DwC name for this field */
@@ -242,6 +244,14 @@ public class IndexFieldDTO implements Comparable<IndexFieldDTO> {
 
     public String getClasss() {
         return classs;
+    }
+
+    public void setFurtherInfo(String furtherInfo) {
+        this.furtherInfo = furtherInfo;
+    }
+
+    public String getFurtherInfo() {
+        return furtherInfo;
     }
 
     public void setMultivalue(boolean multivalue) {

--- a/src/main/java/au/org/ala/biocache/dto/IndexFieldDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/IndexFieldDTO.java
@@ -42,8 +42,8 @@ public class IndexFieldDTO implements Comparable<IndexFieldDTO> {
     private String description;
     /** the i18n information used for this field */
     private String info;
-    /** furtherInfo for this field*/
-    private String furtherInfo;
+    /** info url for this field*/
+    private String infoUrl;
     /** the occurrences/search json key for this field */
     private String jsonName;
     /** the DwC name for this field */
@@ -246,12 +246,12 @@ public class IndexFieldDTO implements Comparable<IndexFieldDTO> {
         return classs;
     }
 
-    public void setFurtherInfo(String furtherInfo) {
-        this.furtherInfo = furtherInfo;
+    public void setInfoUrl(String infoUrl) {
+        this.infoUrl = infoUrl;
     }
 
-    public String getFurtherInfo() {
-        return furtherInfo;
+    public String getInfoUrl() {
+        return infoUrl;
     }
 
     public void setMultivalue(boolean multivalue) {

--- a/src/main/webapp/WEB-INF/messages.properties
+++ b/src/main/webapp/WEB-INF/messages.properties
@@ -958,6 +958,18 @@ duplicates_original_unit_id=Original institution unit associated with duplicate 
 description.taxonomic_issue=Lists any taxonomic data quality issues detected
 description.taxonomic_kosher=A flag indicating if there are serious taxonomic problems with a record. false indicates problems.
 
+# wiki links for some fields
+wiki.basis_of_record=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/basis_of_record
+wiki.duplicate_status=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/duplicate_status
+wiki.taxonomic_issue=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/taxonomic_issue
+wiki.occurrence_decade_i=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/occurrence_decade_i
+wiki.occurrence_status=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/occurrence_status
+wiki.geospatial_kosher=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/geospatial_kosher
+wiki.assertions=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/assertions
+wiki.coordinate_uncertainty=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/coordinate_uncertainty
+wiki.outlier_layer_count=https://github.com/AtlasOfLivingAustralia/ala-dataquality/wiki/outlier_layer_count
+
+
 # Dwc categories - this overrides DwcTerm.group
 class.class=Taxon
 class.identifier_role=Identification


### PR DESCRIPTION
There's a request in https://github.com/AtlasOfLivingAustralia/DataQuality/issues/116 to add a new field for wiki link of some fields.


With this change, the `index/fields` will return below for those with a valid wiki link
<img width="952" alt="Screen Shot 2020-07-17 at 1 27 01 pm" src="https://user-images.githubusercontent.com/61677987/87745452-45e7e700-c831-11ea-8934-7b5454eecff9.png">

And changes will also be made to download plugin (a new column further information added) so `fields` page will look like this:
<img width="1208" alt="Screen Shot 2020-07-17 at 1 31 20 pm" src="https://user-images.githubusercontent.com/61677987/87745668-e63e0b80-c831-11ea-8218-3be496276409.png">



