### PR TITLE
Feature/issue 478 optional do not send email offline download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.47</version>
+            <version>3.4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
         <!-- Mandatory dependencies for using Spock -->
@@ -237,7 +249,7 @@
         <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.6.5</version>
+            <version>1.10.13</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- enables mocking of classes without default constructor (together with CGLIB) -->

--- a/src/main/java/au/org/ala/biocache/dto/DownloadDetailsDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadDetailsDTO.java
@@ -38,6 +38,7 @@ public class DownloadDetailsDTO {
     private String downloadParams;
     private String ipAddress;
     private String userAgent;
+    private boolean emailNotify = true;
     private String email;
     private DownloadRequestParams requestParams;
     private String fileLocation;
@@ -68,6 +69,7 @@ public class DownloadDetailsDTO {
     public DownloadDetailsDTO(DownloadRequestParams params, String ipAddress, String userAgent, DownloadType type){
         this(params.getUrlParams(), ipAddress, userAgent, type);
         requestParams = params;
+        emailNotify = requestParams.isEmailNotify();
         email = requestParams.getEmail();
     }
 
@@ -141,7 +143,15 @@ public class DownloadDetailsDTO {
     public long getTotalRecords(){
         return totalRecords;
     }
-  
+
+    public boolean isEmailNotify() {
+        return emailNotify;
+    }
+
+    public void setEmailNotify(boolean emailNotify) {
+        this.emailNotify = emailNotify;
+    }
+
     /**
      * @return the email
      */

--- a/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
@@ -35,6 +35,7 @@ import java.util.List;
  */
 public class DownloadRequestParams extends SpatialSearchRequestParams {
 
+    protected boolean emailNotify = true;
     protected String email = "";
     protected String reason = "";
     protected String file = "data";
@@ -121,6 +122,10 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
 
     protected String addParams(String paramString, Boolean encodeParams) {
         StringBuilder req = new StringBuilder(paramString);
+        // since emailNotify default is "true", only add param if !emailNotify
+        if (!emailNotify) {
+            req.append("&emailNotify=false");
+        }
         req.append("&email=").append(super.conditionalEncode(email, encodeParams));
         req.append("&reason=").append(super.conditionalEncode(reason, encodeParams));
         req.append("&file=").append(super.conditionalEncode(getFile(), encodeParams));
@@ -150,6 +155,14 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
         }
         
         return req.toString();
+    }
+
+    public boolean isEmailNotify() {
+        return emailNotify;
+    }
+
+    public void setEmailNotify(boolean emailNotify) {
+        this.emailNotify = emailNotify;
     }
 
     public String getEmail() {

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -34,11 +34,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.ala.client.appender.RestLevel;
 import org.ala.client.model.LogEventVO;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -1330,7 +1328,7 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                                     .replace("[hubName]",hubName),
                                     null);
 
-                            if (currentDownload != null && currentDownload.getFileLocation() != null) {
+                            if (currentDownload.isEmailNotify() && currentDownload != null && currentDownload.getFileLocation() != null) {
                                 insertMiscHeader(currentDownload);
 
                                 //ensure new directories have correct permissions


### PR DESCRIPTION
addresses issue #478 

The a new GET request parameter `emailNotify` has been added to the Offline Occurrence download Web Service API `https://biocache-ws.ala.org.au/ws/occurrences/offline/download`. 

The `emailNotify` parameter defaults to `true` use `false` to prevent an email notification when offline download has completed. 