### PR TITLE
#405 client defined download email template

### DIFF
--- a/src/main/java/au/org/ala/biocache/dto/DownloadDoiDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadDoiDTO.java
@@ -166,9 +166,9 @@ public class DownloadDoiDTO {
     }
 
     public void setDisplayTemplate(String displayTemplate) {
-        if (validDisplayTemplates.contains(displayTemplate))
+        if (validDisplayTemplates.contains(displayTemplate)) {
             this.displayTemplate = displayTemplate;
-        else {
+        } else {
             this.displayTemplate = validDisplayTemplates.get(0);
             logger.info("Unsupported displayTemplate passed - " + displayTemplate + ".  Using displayTemplate - " + this.displayTemplate);
         }

--- a/src/main/java/au/org/ala/biocache/dto/DownloadDoiDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadDoiDTO.java
@@ -14,6 +14,10 @@
  ***************************************************************************/
 package au.org.ala.biocache.dto;
 
+import au.org.ala.biocache.service.DoiService;
+import org.apache.log4j.Logger;
+
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +26,10 @@ import java.util.Map;
  * Encapsulates parameters need it to mint a DOI from the offline download functionality
  */
 public class DownloadDoiDTO {
+    public final static List<String> validDisplayTemplates = Arrays.asList(DoiService.DISPLAY_TEMPLATE_BIOCACHE, DoiService.DISPLAY_TEMPLATE_CSDM);
+    /** log4 j logger */
+    private static final Logger logger = Logger.getLogger(DownloadDoiDTO.class);
+
     private String title;
     private String applicationUrl;
     private String query;
@@ -34,6 +42,7 @@ public class DownloadDoiDTO {
     private String requestTime;
     private String queryTitle;
     private List<QualityFilterDTO> qualityFilters = new ArrayList<>();
+    private String displayTemplate;
 
     Map<String, String> applicationMetadata;
 
@@ -150,5 +159,18 @@ public class DownloadDoiDTO {
 
     public void setQualityFilters(List<QualityFilterDTO> qualityFilters) {
         this.qualityFilters = qualityFilters;
+    }
+
+    public String getDisplayTemplate(){
+        return  this.displayTemplate;
+    }
+
+    public void setDisplayTemplate(String displayTemplate) {
+        if (validDisplayTemplates.contains(displayTemplate))
+            this.displayTemplate = displayTemplate;
+        else {
+            this.displayTemplate = validDisplayTemplates.get(0);
+            logger.info("Unsupported displayTemplate passed - " + displayTemplate + ".  Using displayTemplate - " + this.displayTemplate);
+        }
     }
 }

--- a/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
@@ -15,17 +15,20 @@
 
 package au.org.ala.biocache.dto;
 
+import au.org.ala.biocache.service.DoiService;
 import au.org.ala.biocache.service.DownloadService;
 import au.org.ala.biocache.util.QueryFormatUtils;
 import au.org.ala.biocache.validate.LogType;
+import org.apache.log4j.Logger;
 import org.springframework.beans.InvalidPropertyException;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import java.util.Map;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Data Transfer Object to represent the request parameters required to download
@@ -34,6 +37,9 @@ import java.util.List;
  * @author "Natasha Carter <Natasha.Carter@csiro.au>"
  */
 public class DownloadRequestParams extends SpatialSearchRequestParams {
+    public final static List<String> validTemplates = Arrays.asList(DownloadService.DEFAULT_SELECTOR, DownloadService.DOI_SELECTOR, DownloadService.CSDM_SELECTOR);
+    /** log4 j logger */
+    private static final Logger logger = Logger.getLogger(SearchRequestParams.class);
 
     protected boolean emailNotify = true;
     protected String email = "";
@@ -74,6 +80,10 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
     protected Boolean mintDoi=false;
 
     /**
+     * The name of display template to be used to show DOI information.
+     */
+    protected String doiDisplayTemplate = DoiService.DISPLAY_TEMPLATE_BIOCACHE;
+    /**
      * What is the search in the UI that generates this occurrence download.
      */
     protected String searchUrl;
@@ -88,6 +98,11 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
      * This will be used in e-mails, and zip content
      */
     protected String hubName;
+
+    /**
+     * Specify email template to use when informing
+     */
+    protected String emailTemplate = validTemplates.get(0);
 
     /**
      * If a DOI is to be minted containing download data, this allows the requesting application to attach
@@ -267,6 +282,8 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
         return fileType;
     }
 
+    public String getEmailTemplate() { return emailTemplate; }
+
     /**
      * @param fileType the fileType to set
      */
@@ -387,4 +404,20 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
         this.qualityFiltersInfo = qualityFiltersInfo;
     }
 
+    public void setEmailTemplate(String emailTemplate) {
+        if( validTemplates.contains(emailTemplate) )
+            this.emailTemplate = emailTemplate;
+        else {
+            this.emailTemplate = validTemplates.get(0);
+            logger.info("Unsupported emailTemplate passed - " + emailTemplate + ".  Using emailTemplate - " + this.emailTemplate);
+        }
+    }
+
+    public String getDoiDisplayTemplate() {
+        return this.doiDisplayTemplate;
+    }
+
+    public void setDoiDisplayTemplate(String doiDisplayTemplate) {
+        this.doiDisplayTemplate = doiDisplayTemplate;
+    }
 }

--- a/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
+++ b/src/main/java/au/org/ala/biocache/dto/DownloadRequestParams.java
@@ -282,7 +282,9 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
         return fileType;
     }
 
-    public String getEmailTemplate() { return emailTemplate; }
+    public String getEmailTemplate() {
+        return emailTemplate;
+    }
 
     /**
      * @param fileType the fileType to set
@@ -405,9 +407,9 @@ public class DownloadRequestParams extends SpatialSearchRequestParams {
     }
 
     public void setEmailTemplate(String emailTemplate) {
-        if( validTemplates.contains(emailTemplate) )
+        if( validTemplates.contains(emailTemplate) ) {
             this.emailTemplate = emailTemplate;
-        else {
+        } else {
             this.emailTemplate = validTemplates.get(0);
             logger.info("Unsupported emailTemplate passed - " + emailTemplate + ".  Using emailTemplate - " + this.emailTemplate);
         }

--- a/src/main/java/au/org/ala/biocache/service/DoiService.java
+++ b/src/main/java/au/org/ala/biocache/service/DoiService.java
@@ -39,7 +39,8 @@ import java.util.concurrent.TimeUnit;
 public class DoiService {
 
     private static final Logger logger = Logger.getLogger(DoiService.class);
-    public static final String DISPLAY_TEMPLATE = "biocache";
+    public static final String DISPLAY_TEMPLATE_BIOCACHE = "biocache";
+    public static final String DISPLAY_TEMPLATE_CSDM = "csdm";
 
     @Value("${doi.service.url:https://devt.ala.org.au/doi-service/api/}")
     private String doiServiceUrl;
@@ -153,7 +154,7 @@ public class DoiService {
 
         request.setProvider(Provider.ANDS.name());
         request.setFileUrl(downloadInfo.getFileUrl());
-        request.setDisplayTemplate(DISPLAY_TEMPLATE);
+        request.setDisplayTemplate(downloadInfo.getDisplayTemplate());
 
 
         Map<String, Object> providerMetadata = generateProviderMetadataPayload(downloadInfo);

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -1420,19 +1420,6 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
 
                                 if (currentDownload.isEmailNotify()) {
 
-//                                    emailBody = Files.asCharSource(new File(emailTemplate), StandardCharsets.UTF_8).read();
-//
-//                                    final String searchUrl = generateSearchUrl(currentDownload.getRequestParams());
-//                                    String emailBodyHtml = emailBody.replace("[url]", downloadFileLocation)
-//                                            .replace("[officialDoiUrl]", officialFileLocation)
-//                                       *     .replace("[date]", currentDownload.getStartDateString(downloadDateFormat))
-//                                       *     .replace("[searchUrl]", searchUrl)
-//                                       *     .replace("[queryTitle]", currentDownload.getRequestParams().getDisplayString())
-//                                            .replace("[doiFailureMessage]", doiFailureMessage);
-//                                    String body = messageSource.getMessage("offlineEmailBody",
-//                                            new Object[]{archiveFileLocation, searchUrl, currentDownload.getStartDateString(downloadDateFormat)},
-//                                            emailBodyHtml, null);
-
                                     // save the statistics to the download directory
                                     try (FileOutputStream statsStream = FileUtils
                                             .openOutputStream(new File(new File(currentDownload.getFileLocation()).getParent()

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -1385,7 +1385,7 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                                 substitutions.put(START_DATE_TIME, currentDownload.getStartDateString(downloadDateFormat));
                                 substitutions.put(QUERY_TITLE, currentDownload.getRequestParams().getDisplayString());
                                 substitutions.put(SEARCH_URL, searchUrl);
-                                substitutions.put(DOI_FAILURE_MESSAGE,  biocacheDownloadDoiFailureMessage);
+                                substitutions.put(DOI_FAILURE_MESSAGE,  doiFailureMessage);
 
                                 if(mintDoi && doiResponseList != null && !doiResponseList.isEmpty() && doiResponseList.get(0) != null) {
 

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -1394,8 +1394,9 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
                                     try {
                                         doiService.updateFile(doiResponse.getUuid(), currentDownload.getFileLocation());
                                         doiStr = doiResponse.getDoi();
-                                        if (currentDownload.getRequestParams().getEmailTemplate() == DEFAULT_SELECTOR)
+                                        if (currentDownload.getRequestParams().getEmailTemplate() == DEFAULT_SELECTOR) {
                                             currentDownload.getRequestParams().setEmailTemplate(DOI_SELECTOR);
+                                        }
 
                                         // TODO: The downloads-plugin has issues with unencoded user queries 
                                         // Working around that by hardcoding the official DOI resolution service as the landing page

--- a/src/main/webapp/WEB-INF/messages.properties
+++ b/src/main/webapp/WEB-INF/messages.properties
@@ -657,6 +657,8 @@ month.12=December
 
 # Email
 #offlineEmailBody=Testing email body {0}
+offlineFailEmailBody=Your [hubName] download has failed. Please contact [support] by replying to this email and we will investigate the cause. <br><br>Your search URL was: <br> [searchUrl]<br><br>The reference to quote is:<br> [uniqueId] <br><br>Your successful downloads can be found at:<br> [myDownloadsUrl]
+offlineFailEmailBodyCSDM=Your [hubName] download has failed. You will not be able to import data for modelling. Please try again after some time or contact [support] by replying to this email and we will investigate the cause.
 
 # Validation error messages
 NotNull=A mandatory field has been left null

--- a/src/main/webapp/WEB-INF/messages.properties
+++ b/src/main/webapp/WEB-INF/messages.properties
@@ -658,7 +658,7 @@ month.12=December
 # Email
 #offlineEmailBody=Testing email body {0}
 offlineFailEmailBody=Your [hubName] download has failed. Please contact [support] by replying to this email and we will investigate the cause. <br><br>Your search URL was: <br> [searchUrl]<br><br>The reference to quote is:<br> [uniqueId] <br><br>Your successful downloads can be found at:<br> [myDownloadsUrl]
-offlineFailEmailBodyCSDM=Your [hubName] download has failed. You will not be able to import data for modelling. Please try again after some time or contact [support] by replying to this email and we will investigate the cause.
+offlineFailEmailBodyCSDM=Your [hubName] download has failed. You will not be able to import data for modelling. Please try again after some time or contact [support] by replying to this email and we will investigate the cause.<br><br>The reference to quote is:<br> [uniqueId]
 
 # Validation error messages
 NotNull=A mandatory field has been left null

--- a/src/test/java/au/org/ala/biocache/dao/PersistentQueueDAOTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/PersistentQueueDAOTest.java
@@ -5,6 +5,7 @@ import au.org.ala.biocache.dto.DownloadDetailsDTO.DownloadType;
 import au.org.ala.biocache.dto.DownloadRequestParams;
 import au.org.ala.biocache.service.DownloadService;
 import au.org.ala.biocache.dto.FacetThemes;
+import au.org.ala.biocache.service.DownloadService;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -41,6 +42,7 @@ public class PersistentQueueDAOTest {
         //init FacetThemes
         new FacetThemes();
 
+        DownloadService.downloadShpEnabled = true;
         testCacheDir = tempDir.newFolder("persistentqueuedaotest-cache").toPath();
         testDownloadDir = tempDir.newFolder("persistentqueuedaotest-destination").toPath();        
         queueDAO = new JsonPersistentQueueDAOImpl() {

--- a/src/test/java/au/org/ala/biocache/dto/DownloadRequestParamsTest.java
+++ b/src/test/java/au/org/ala/biocache/dto/DownloadRequestParamsTest.java
@@ -78,7 +78,6 @@ public class DownloadRequestParamsTest {
         downloadRequestParams.setEmailTemplate("csdm");
         assertTrue("csdm".equals(downloadRequestParams.getEmailTemplate()));
 
-
         downloadRequestParams = new DownloadRequestParams();
         downloadRequestParams.setEmailTemplate("uuidaof");
         assertFalse("uuidaof".equals(downloadRequestParams.getEmailTemplate()));

--- a/src/test/java/au/org/ala/biocache/dto/DownloadRequestParamsTest.java
+++ b/src/test/java/au/org/ala/biocache/dto/DownloadRequestParamsTest.java
@@ -29,7 +29,7 @@ public class DownloadRequestParamsTest {
     }
 
     /**
-     * Test for {@link DownloadRequestParams#setFileType(Boolean)}.
+     * Test for {@link DownloadRequestParams#setFileType(String)}.
      */
     @Test
     public final void testSetFileType() throws Exception {
@@ -61,4 +61,27 @@ public class DownloadRequestParamsTest {
         assertFalse("shp".equals(downloadRequestParams.getFileType()));
     }
 
+    /**
+     * Test for {@link DownloadRequestParams#setEmailTemplate(String)}.
+     */
+    @Test
+    public final void testSetEmailTemplate() throws Exception {
+
+        DownloadRequestParams downloadRequestParams = new DownloadRequestParams();
+        assertTrue("default".equals(downloadRequestParams.getEmailTemplate()));
+
+        downloadRequestParams = new DownloadRequestParams();
+        downloadRequestParams.setEmailTemplate("doi");
+        assertTrue("doi".equals(downloadRequestParams.getEmailTemplate()));
+
+        downloadRequestParams = new DownloadRequestParams();
+        downloadRequestParams.setEmailTemplate("csdm");
+        assertTrue("csdm".equals(downloadRequestParams.getEmailTemplate()));
+
+
+        downloadRequestParams = new DownloadRequestParams();
+        downloadRequestParams.setEmailTemplate("uuidaof");
+        assertFalse("uuidaof".equals(downloadRequestParams.getEmailTemplate()));
+        assertTrue("default".equals(downloadRequestParams.getEmailTemplate()));
+    }
 }


### PR DESCRIPTION
This PR is intended to resolve the issues with merge and subsequent revert of PR #411 & #445 and from branches from [`hotfix/doimetadata`](https://github.com/AtlasOfLivingAustralia/biocache-service/tree/hotfix/doimetadata) (closed PR #444).

The suggested code review changes from [PR #444](https://github.com/AtlasOfLivingAustralia/biocache-service/pull/444/files) have been made with the exception of https://github.com/AtlasOfLivingAustralia/biocache-service/pull/444/files#r405216593.

It should be possible to display templates configurable but I suggest a new PR to implement this. 