### PR TITLE
issue #479 validate email address for offline downloads against user details

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -202,6 +202,7 @@ public class DownloadController extends AbstractSecureController {
                 return null;
             }
 
+            boolean activated = (Boolean) userDetails.get("activated");
             boolean locked = (Boolean) userDetails.get("locked");
             boolean hasRole = false;
 
@@ -214,7 +215,7 @@ public class DownloadController extends AbstractSecureController {
                 hasRole = roles == null ? false : roles.stream().anyMatch(downloadRole::equals);
             }
 
-            if (locked || !hasRole) {
+            if (!activated || locked || !hasRole) {
 
                 response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download without insufficient privileges");
                 return null;

--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.SolrDocumentList;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,6 +72,9 @@ public class DownloadController extends AbstractSecureController {
 
     @Inject
     protected DownloadService downloadService;
+
+    @Value("${download.auth.role:ROLE_USER}")
+    String downloadRole;
 
     /**
      * Retrieves all the downloads that are on the queue
@@ -118,13 +122,14 @@ public class DownloadController extends AbstractSecureController {
             DownloadRequestParams requestParams,
             @RequestParam(value = "ip", required = false) String ip,
             @RequestParam(value = "apiKey", required = false) String apiKey,
+            @RequestParam(value = "email", required = true) String email,
             @PathVariable("type") String type,
             HttpServletResponse response,
             HttpServletRequest request) throws Exception {
 
         DownloadDetailsDTO.DownloadType downloadType = "index".equals(type.toLowerCase()) ? DownloadDetailsDTO.DownloadType.RECORDS_INDEX : DownloadDetailsDTO.DownloadType.RECORDS_DB;
 
-        return download(requestParams, ip, getUserAgent(request), apiKey, response, request, downloadType);
+        return download(requestParams, ip, getUserAgent(request), apiKey, email, response, request, downloadType);
     }
 
     /**
@@ -142,11 +147,13 @@ public class DownloadController extends AbstractSecureController {
             DownloadRequestParams requestParams,
             @RequestParam(value = "ip", required = false) String ip,
             @RequestParam(value = "apiKey", required = false) String apiKey,
+            @RequestParam(value = "email", required = true) String email,
             HttpServletResponse response,
             HttpServletRequest request) throws Exception {
 
-        if (StringUtils.isEmpty(requestParams.getEmail())) {
+        if (StringUtils.isEmpty(email)) {
             response.sendError(400, "Required parameter 'email' is not present");
+            return null;
         }
 
         //download from index only when there are no CASSANDRA fields requested and not everything is in SOLR
@@ -169,23 +176,64 @@ public class DownloadController extends AbstractSecureController {
 
         DownloadDetailsDTO.DownloadType downloadType = hasDBColumn ? DownloadDetailsDTO.DownloadType.RECORDS_DB : DownloadDetailsDTO.DownloadType.RECORDS_INDEX;
 
-        return download(requestParams, ip, getUserAgent(request), apiKey, response, request, downloadType);
+        return download(requestParams, ip, getUserAgent(request), apiKey, email, response, request, downloadType);
     }
 
-    private Object download(DownloadRequestParams requestParams, String ip, String userAgent, String apiKey,
+    private Object download(DownloadRequestParams requestParams, String ip, String userAgent, String apiKey, String email,
                             HttpServletResponse response, HttpServletRequest request,
                             DownloadDetailsDTO.DownloadType downloadType) throws Exception {
+
+        // check the email is supplied and a matching user account exists with the required privileges
+        if (StringUtils.isEmpty(email)) {
+
+            response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED, "Unable to perform an offline download without an email address");
+            return null;
+
+        }
+
+        // lookup the user details and check privileges based on the supplied email
+        try {
+
+            Map<String, ?> userDetails = authService.getUserDetails(email);
+
+            if (userDetails == null) {
+
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download matching user details");
+                return null;
+            }
+
+            boolean locked = (Boolean) userDetails.get("locked");
+            boolean hasRole = false;
+
+            if (downloadRole == null) {
+                // no download role defined, allow based on role privileges
+                hasRole = true;
+            } else {
+                // check that the user roles contains the download role
+                List<String> roles = (List<String>) userDetails.get("roles");
+                hasRole = roles == null ? false : roles.stream().anyMatch(downloadRole::equals);
+            }
+
+            if (locked || !hasRole) {
+
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download without insufficient privileges");
+                return null;
+            }
+
+        } catch (Exception e) {
+
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download cannot verify user details");
+            return null;
+        }
 
         boolean includeSensitive = false;
         if (apiKey != null) {
             if (shouldPerformOperation(apiKey, response, false)) {
                 includeSensitive = true;
             }
-        } else if (StringUtils.isEmpty(requestParams.getEmail())) {
-            response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED, "Unable to perform an offline download without an email address");
         }
 
-        //Pre SDS roles the sensitive flag controlled access to sensitive data.
+        // Pre SDS roles the sensitive flag controlled access to sensitive data.
         // After SDS roles were introduced, sensitiveFq variable drives the logic for sensitive data down the excution flow.
 
         // In Summary either sensitive is true or sensitiveFq is not null but not both

--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -194,16 +194,16 @@ public class DownloadController extends AbstractSecureController {
         // lookup the user details and check privileges based on the supplied email
         try {
 
-            Map<String, ?> userDetails = authService.getUserDetails(email);
+            Map<String, Object> userDetails = (Map<String, Object>) authService.getUserDetails(email);
 
             if (userDetails == null) {
 
-                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download matching user details");
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download, user not recognised");
                 return null;
             }
 
-            boolean activated = (Boolean) userDetails.get("activated");
-            boolean locked = (Boolean) userDetails.get("locked");
+            boolean activated = (Boolean) userDetails.getOrDefault("activated", false);
+            boolean locked = (Boolean) userDetails.getOrDefault("locked", true);
             boolean hasRole = false;
 
             if (downloadRole == null) {
@@ -217,13 +217,13 @@ public class DownloadController extends AbstractSecureController {
 
             if (!activated || locked || !hasRole) {
 
-                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download without insufficient privileges");
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download, insufficient privileges");
                 return null;
             }
 
         } catch (Exception e) {
 
-            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download cannot verify user details");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to perform an offline download, unable to verify user details");
             return null;
         }
 

--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -1,0 +1,138 @@
+package au.org.ala.biocache.controller;
+
+import au.org.ala.biocache.service.AuthService;
+import au.org.ala.biocache.service.DownloadService;
+import au.org.ala.biocache.service.LoggerService;
+import au.org.ala.biocache.web.DownloadController;
+import au.org.ala.biocache.web.OccurrenceController;
+import com.google.common.collect.ImmutableMap;
+import junit.framework.TestCase;
+import org.ala.client.model.LogEventVO;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for occurrence services.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:springTest.xml"})
+@WebAppConfiguration
+public class DownloadControllerTest extends TestCase {
+
+    static {
+        System.setProperty("biocache.config", System.getProperty("user.dir") + "/src/test/resources/biocache-test-config.properties");
+    }
+
+    public final int TEST_INDEX_SIZE = 1000;
+    public final int DEFAULT_SEARCH_PAGE_SIZE = 10;
+    public final int INDEXED_FIELD_SIZE = 377;
+
+    @Autowired
+    DownloadController downloadController;
+
+    @Autowired
+    DownloadService downloadService;
+
+    AuthService authService;
+
+    @Autowired
+    WebApplicationContext wac;
+
+    MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+
+        authService = mock(AuthService.class);
+        ReflectionTestUtils.setField(downloadController, "authService", authService);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    @Test
+    public void offlineDownloadValidEmailTest() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn((Map)ImmutableMap.of(
+                        "locked", false,
+                        "roles", Arrays.asList("ROLE_USER")
+                ));
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+
+    @Test
+    public void downloadInvalidEmailTest() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn(null);
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().is4xxClientError());
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+
+    @Test
+    public void downloadLockedEmailTest() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn((Map)ImmutableMap.of(
+                        "locked", true
+                ));
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().is4xxClientError());
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+
+    @Test
+    public void downloadNoRoleEmailTest() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn((Map)ImmutableMap.of(
+                        "locked", false,
+                        "roles", Arrays.asList("NO_ROLE")
+                ));
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().is4xxClientError());
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+}

--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -93,6 +93,8 @@ public class DownloadControllerTest extends TestCase {
 
         ReflectionTestUtils.setField(downloadController, "authService", authService);
         ReflectionTestUtils.setField(downloadController, "persistentQueueDAO", persistentQueueDao);
+
+        downloadService.biocacheDownloadDir = testDownloadDir.toAbsolutePath().toString();
         ReflectionTestUtils.setField(downloadService, "persistentQueueDAO", persistentQueueDao);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();

--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -76,6 +76,7 @@ public class DownloadControllerTest extends TestCase {
 
         when(authService.getUserDetails("test@test.com"))
                 .thenReturn((Map)ImmutableMap.of(
+                        "activated", true,
                         "locked", false,
                         "roles", Arrays.asList("ROLE_USER")
                 ));
@@ -108,6 +109,7 @@ public class DownloadControllerTest extends TestCase {
 
         when(authService.getUserDetails("test@test.com"))
                 .thenReturn((Map)ImmutableMap.of(
+                        "activated", true,
                         "locked", true
                 ));
 
@@ -124,6 +126,7 @@ public class DownloadControllerTest extends TestCase {
 
         when(authService.getUserDetails("test@test.com"))
                 .thenReturn((Map)ImmutableMap.of(
+                        "activated", true,
                         "locked", false,
                         "roles", Arrays.asList("NO_ROLE")
                 ));

--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -92,6 +92,7 @@ public class DownloadControllerTest extends TestCase {
         authService = mock(AuthService.class);
 
         ReflectionTestUtils.setField(downloadController, "authService", authService);
+        ReflectionTestUtils.setField(downloadController, "persistentQueueDAO", persistentQueueDao);
         ReflectionTestUtils.setField(downloadService, "persistentQueueDAO", persistentQueueDao);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();


### PR DESCRIPTION
added validation of the userdetails for email address supplied with the download request. 

The user details properties must be:
 - activated 
 - !locked
 - roles contains config `${download.auth.role:ROLE_USER}` 