### PR TITLE
Issue #502 occurrence search failed on fq=month:"03" month:"04"

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -4251,7 +4251,7 @@ public class SearchDAOImpl implements SearchDAO {
             }
         }
 
-        return facet + ":\"" + value + "\"";
+        return facet + ":\"" + value.replace("\"", "\\\"") + "\"";
     }
 
     /**

--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -913,6 +913,14 @@ public class QueryFormatUtils {
                             extractedValue = extractedValue.substring(0, extractedValue.indexOf(" OR "));
                         }
 
+                        // search for term in the extractedValue and clip
+                        // NOTE: the if the quoted term value contains content that looks like a term "name" then it will be
+                        //       treated as a new term.
+                        Matcher termMatcher = termPattern.matcher(extractedValue);
+                        if (termMatcher.find()) {
+                            extractedValue = extractedValue.substring(0, termMatcher.start());
+                        }
+
                         // below code fragment extracts the filter value and try to format for solr query or get display value
                         // &fq = taxon_name:""Cyclophora"+lechriostropha"
                         // the old implementation yields this fq to be sent to solr: taxon_name:"\"Cyclophora",

--- a/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
@@ -168,7 +168,8 @@ public class FilterQueryParserTest {
                 {"month:\"09\"", "Month:\"September\""},
                 {"(month:\"09\")", "(Month:\"September\")"},
                 {"month:\"09\" OR month:\"10\"", "Month:\"September\" OR Month:\"October\""},
-                {"(month:\"09\" OR month:\"10\")", "(Month:\"September\" OR Month:\"October\")"}};
+                {"(month:\"09\" OR month:\"10\")", "(Month:\"September\" OR Month:\"October\")"}
+        };
 
         for (String[] fq : fqs) {
             query.setFq(new String[] { fq[0] });

--- a/src/test/java/au/org/ala/biocache/dao/QueryFormatTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/QueryFormatTest.java
@@ -161,7 +161,9 @@ public class QueryFormatTest {
                 //new SearchQueryTester("matched_name_children:\"kangurus lanosus\"", "lft:[", "found", false),
                 //new SearchQueryTester("(matched_name_children:Mammalia OR matched_name_children:whales)", "lft:[", "class:", false),
                 //new SearchQueryTester("collector_text:Latz AND matched_name_children:\"Pluchea tetranthera\"", "as","as",false)
-                new SearchQueryTester("spatial_list:dr123", "", "", false)
+                new SearchQueryTester("spatial_list:dr123", "", "", false),
+                new SearchQueryTester("month:03 month:04", "month:03 month:04", "Month:March Month:April", true),
+                new SearchQueryTester("month:\"03\" month:\"04\"", "month:\"03\" month:\"04\"", "Month:\"March\" Month:\"April\"", true),
         };
     }
 


### PR DESCRIPTION
Clips the quoted `extractedValue` at the next match of the termPattern. 
This should stop escaping of quotes when the next term is encounter. 

**Note:** if the quoted terms `extractedValue` contains a string that matches the termPattern then processing will terminate.