### PR TITLE
updated implementation of QueryFormatUtils::parseFQ

### DIFF
--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -215,13 +215,17 @@ public class QueryFormatUtils {
      */
     private String parseFQ(String fq) {
         fq = StringUtils.trimToEmpty(fq);
-        if ((fq.startsWith("-(") || fq.startsWith("(")) && !fq.endsWith(")")) return null;
+        if ((fq.startsWith("-(") || fq.startsWith("(")) && !fq.endsWith(")")) {
+            return null;
+        }
 
         boolean globalInclusive = true;
         if (fq.startsWith("-(") && fq.endsWith(")")) {
             fq = fq.substring(2, fq.length() - 1);
             globalInclusive = false;
-        } else if (fq.startsWith("(") && fq.endsWith(")")) fq = fq.substring(1, fq.length() - 1);
+        } else if (fq.startsWith("(") && fq.endsWith(")")) {
+            fq = fq.substring(1, fq.length() - 1);
+        }
 
         if (StringUtils.isNotEmpty(fq)) {
             String[] fv = fq.split(":");

--- a/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
@@ -221,7 +221,7 @@ public class FilterQueryParserTest {
     public void testActiveFacetObj_invalidfq() {
         SpatialSearchRequestParams query = new SpatialSearchRequestParams();
         // Construct fq
-        query.setFq(new String[] {null, "", " ", "month", "   month  ", "(month", "month)", "(month:\"11\"", "month:\"11\" )", "month\"11\"", ":\"11\"", "    :\"11\"", "(:\"11\")", "(    :\"11\")", "month:", "month:   ",  "(month:   )", "-(month:   )"});
+        query.setFq(new String[] {null, "", " ", "month", "   month  ", "(month", "month)", "(month:\"11\"", "month\"11\"", ":\"11\"", "    :\"11\"", "(:\"11\")", "(    :\"11\")", "month:", "month:   ",  "(month:   )", "-(month:   )"});
         assertTrue(queryFormatUtils.formatSearchQuery(query)[1].isEmpty());
     }
 }

--- a/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
@@ -202,6 +202,8 @@ public class FilterQueryParserTest {
         facetList.add(new Facet("occurrence_decade_i", "(Decade:\"2010\" OR Decade:\"2000\")", "(occurrence_decade_i:\"2010\" OR occurrence_decade_i:\"2000\")"));
         facetList.add(new Facet("occurrence_decade_i", "(Decade:\"2010\" OR Decade:\"2000\" OR Decade:\"1990\" OR Decade:\"1980\")", "(occurrence_decade_i:\"2010\" OR occurrence_decade_i:\"2000\" OR occurrence_decade_i:\"1990\" OR occurrence_decade_i:\"1980\")"));
 
+        facetList.add(new Facet("license", "license:\"CC BY NC\" license:\"CC BY NC 4.0 (Int)\"", "license:\"CC BY NC\" license:\"CC BY NC 4.0 (Int)\""));
+
         runFqParsingTest(facetList);
     }
 


### PR DESCRIPTION
Old implementation failed to parse `license:"CC BY NC" license:"CC BY NC 4.0 (Int)" `