### PR TITLE
Hotfix for issue#540 : Backwards compatibility for userdetails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>au.org.ala</groupId>
     <artifactId>biocache-service</artifactId>
     <packaging>war</packaging>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
     <name>biocache-service</name>
     <url>https://biocache-ws.ala.org.au/ws</url>
     <description>This is a the service layer for the ALA Biocache.

--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -208,7 +208,7 @@ public class DownloadController extends AbstractSecureController {
                 return null;
             }
 
-            boolean activated = (Boolean) userDetails.getOrDefault("activated", false);
+            boolean activated = (Boolean) userDetails.getOrDefault("activated", true);
             boolean locked = (Boolean) userDetails.getOrDefault("locked", true);
             boolean hasRole = false;
 

--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -101,11 +101,29 @@ public class DownloadControllerTest extends TestCase {
     }
 
     @Test
-    public void offlineDownloadValidEmailTest() throws Exception {
+    public void offlineDownloadValidEmailTestAllAttributes() throws Exception {
 
         when(authService.getUserDetails("test@test.com"))
                 .thenReturn((Map)ImmutableMap.of(
                         "activated", true,
+                        "locked", false,
+                        "roles", Arrays.asList("ROLE_USER")
+                ));
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+
+    @Test
+    public void offlineDownloadValidEmailTestNoActivated() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn((Map)ImmutableMap.of(
                         "locked", false,
                         "roles", Arrays.asList("ROLE_USER")
                 ));
@@ -158,6 +176,24 @@ public class DownloadControllerTest extends TestCase {
                         "activated", true,
                         "locked", false,
                         "roles", Arrays.asList("NO_ROLE")
+                ));
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().is4xxClientError());
+
+        verify(authService).getUserDetails("test@test.com");
+    }
+
+    @Test
+    public void downloadActivatedFalseEmailTest() throws Exception {
+
+        when(authService.getUserDetails("test@test.com"))
+                .thenReturn((Map)ImmutableMap.of(
+                        "activated", false,
+                        "locked", false,
+                        "roles", Arrays.asList("ROLE_USER")
                 ));
 
         this.mockMvc.perform(get("/occurrences/offline/download*")


### PR DESCRIPTION
This adds backwards compatibility for previous userdetails versions that do not expose the `activated` attribute for users.

Includes regression tests to ensure backwards compatibility in future.