### PR TITLE
issue #546 Download check for registered users should be optional via config

### DIFF
--- a/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/DownloadControllerTest.java
@@ -152,6 +152,20 @@ public class DownloadControllerTest extends TestCase {
     }
 
     @Test
+    public void downloadInvalidEmailByPassAuthTest() throws Exception {
+
+        boolean authBypass = (boolean) ReflectionTestUtils.getField(downloadController, "authBypass");
+        ReflectionTestUtils.setField(downloadController, "authBypass", true);
+
+        this.mockMvc.perform(get("/occurrences/offline/download*")
+                .param("reasonTypeId", "10")
+                .param("email", "test@test.com"))
+                .andExpect(status().isOk());
+
+        ReflectionTestUtils.setField(downloadController, "authBypass", authBypass);
+    }
+
+    @Test
     public void downloadLockedEmailTest() throws Exception {
 
         when(authService.getUserDetails("test@test.com"))


### PR DESCRIPTION
added config property `download.auth.bypass` to bypass authorisation of email for downloads

