### PR TITLE
issue #495 Fix hardcoded 1,000,000 page size for WMS uncertainty queries

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -77,7 +77,8 @@ public class WMSController extends AbstractSecureController{
     /**
      * webportal results limit
      */
-    private final int DEFAULT_PAGE_SIZE = 1000000;
+    @Value("${wms.pagesize:1000000}")
+    private int DEFAULT_PAGE_SIZE = 1000000;
 
     @Value("${wms.colour:0x00000000}")
     private int DEFAULT_COLOUR;


### PR DESCRIPTION
set configurable default page size `wms.pagesize`