### PR TITLE
issue #524 : ListService::find fails with IndexOutOfBoundsException

### DIFF
--- a/src/main/java/au/org/ala/biocache/service/ListsService.java
+++ b/src/main/java/au/org/ala/biocache/service/ListsService.java
@@ -300,7 +300,7 @@ public class ListsService {
             return kvps.get(idx);
         } else {
             // reverse through kvps until a match is found
-            idx = idx * -1;
+            idx = Math.min(idx * -1, kvps.size() -1);
             while (idx >= 0) {
                 if (kvps.get(idx).contains(lftrgt)) {
                     return kvps.get(idx);

--- a/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
@@ -2,27 +2,48 @@ package au.org.ala.biocache.service
 
 import au.org.ala.biocache.dto.Kvp
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ListsServiceSpec extends Specification {
 
     ListsService listService = new ListsService()
 
-    def 'find Kpv'() {
+    @Unroll
+    def 'find Kpv(lft: #lft, rgt: #rgt)'() {
 
         setup:
         List<Kvp> kvps = [
-                new Kvp(1, 1),
-                new Kvp(2, 2),
-                new Kvp(3, 3)
+                new Kvp(10, 10),
+                new Kvp(20, 20),
+                new Kvp(24, 26),
+                new Kvp(30, 30)
         ]
 
 
-        Kvp lftrgt = new Kvp(4, 4)
-
         when:
-        Kvp result = listService.find(kvps, lftrgt)
+        Kvp result = listService.find(kvps, new Kvp(lft, rgt))
 
         then:
-        result == null
+        if (expectedKvp != null) {
+
+            result.lft == expectedKvp.lft
+            result.rgt == expectedKvp.rgt
+
+        } else {
+            result == null
+        }
+
+        where:
+        lft | rgt || expectedKvp
+        1   | 1   || null
+        10  | 10  || new Kvp(10, 10)
+        19  | 21  || null
+        24  | 26  || new Kvp(24, 26)
+        25  | 25  || null
+        29  | 30  || null
+        30  | 30  || new Kvp(30, 30)
+        30  | 31  || null
+        40  | 40  || null
+
     }
 }

--- a/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
@@ -24,14 +24,9 @@ class ListsServiceSpec extends Specification {
         Kvp result = listService.find(kvps, new Kvp(lft, rgt))
 
         then:
-        if (expectedKvp != null) {
-
-            result.lft == expectedKvp.lft
-            result.rgt == expectedKvp.rgt
-
-        } else {
-            result == null
-        }
+        expectedKvp != null || result == null
+        expectedKvp == null || result.lft == expectedKvp.lft
+        expectedKvp == null || result.rgt == expectedKvp.rgt
 
         where:
         lft | rgt || expectedKvp
@@ -39,11 +34,10 @@ class ListsServiceSpec extends Specification {
         10  | 10  || new Kvp(10, 10)
         19  | 21  || null
         24  | 26  || new Kvp(24, 26)
-        25  | 25  || null
+        25  | 25  || new Kvp(24, 26)
         29  | 30  || null
         30  | 30  || new Kvp(30, 30)
         30  | 31  || null
         40  | 40  || null
-
     }
 }

--- a/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/ListsServiceSpec.groovy
@@ -1,0 +1,28 @@
+package au.org.ala.biocache.service
+
+import au.org.ala.biocache.dto.Kvp
+import spock.lang.Specification
+
+class ListsServiceSpec extends Specification {
+
+    ListsService listService = new ListsService()
+
+    def 'find Kpv'() {
+
+        setup:
+        List<Kvp> kvps = [
+                new Kvp(1, 1),
+                new Kvp(2, 2),
+                new Kvp(3, 3)
+        ]
+
+
+        Kvp lftrgt = new Kvp(4, 4)
+
+        when:
+        Kvp result = listService.find(kvps, lftrgt)
+
+        then:
+        result == null
+    }
+}


### PR DESCRIPTION
The `ListService:find` method performed a partial match if an exact match does not exists. This partial match is run in reverse order of the point at which the exact match should have appeared in the sorted list. 

If the find if for a `Kvp` that is > then and within the list then the index is set to the list size +1 which is causing a failure when trying a partial match. 