### PR TITLE
issue #390 : IndexOutOfBoundsException in SpeciesLookupRestService

### DIFF
--- a/src/main/java/au/org/ala/biocache/service/SpeciesLookupRestService.java
+++ b/src/main/java/au/org/ala/biocache/service/SpeciesLookupRestService.java
@@ -204,7 +204,7 @@ public class SpeciesLookupRestService implements SpeciesLookupService {
                     // merge with results from cache
                     int resultsPos = 0;
                     int unknownPos = 0;
-                    while (resultsPos < guids.size() && unknownPos < unknown.size()) {
+                    while (resultsPos < results.size() && unknownPos < unknown.size() && unknownPos < unknownResults.size()) {
                         if (results.get(resultsPos) == null) {
                             nameDetailsForGuidsCache.put(unknown.get(unknownPos), unknownResults.get(unknownPos));
                             results.set(resultsPos, unknownResults.get(unknownPos++));


### PR DESCRIPTION
Added extra checks that the index into the lists (`unknownPos`) < all of the lists size.

The size of the unknown GUIDs (`unknown`) should be the same and the results of [Bulk lookup by GUID](https://api.ala.org.au/#ws110), any GUIDs that are not found will result in NULL within the results array. 