### PR TITLE
issue #514 send log events asynchronously

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,11 @@
             <version>3.2.2</version>
         </dependency>
         <!-- JMS setting end-->
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>3.0.6</version>
+        </dependency>
         <!-- SITEMESH -->
         <dependency>
             <groupId>opensymphony</groupId>

--- a/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
@@ -3,6 +3,8 @@ package au.org.ala.biocache.service
 import org.ala.client.model.LogEventVO
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestOperations
 import spock.lang.Specification
 
@@ -26,6 +28,35 @@ class LoggerServiceSpec extends Specification {
         Thread.sleep(1000)
 
         then:
-        1 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void)
+        1 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
+    }
+
+    void 'thottle log events'() {
+
+        setup:
+        LoggerRestService loggerService = new LoggerRestService()
+        loggerService.enabled = false
+        loggerService.restTemplate = Mock(RestOperations)
+        loggerService.throttleDelay = 100
+
+        loggerService.init()
+
+        LogEventVO logEvent = new LogEventVO()
+        HttpHeaders headers = new HttpHeaders()
+        headers.set(HttpHeaders.USER_AGENT, logEvent.getUserAgent())
+
+        when: 'log more then buffer in quick succession'
+        10.times {
+            loggerService.logEvent(logEvent)
+        }
+
+        then:
+        0 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
+
+        when:
+        Thread.sleep(10 * loggerService.throttleDelay)
+
+        then: 'expect all events POSTed'
+        10 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
     }
 }

--- a/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
@@ -31,6 +31,78 @@ class LoggerServiceSpec extends Specification {
         1 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
     }
 
+    void 'block on queue limit'() {
+
+        setup:
+        LoggerRestService loggerService = new LoggerRestService()
+        loggerService.enabled = false
+        loggerService.restTemplate = Stub(RestOperations) {
+            postForEntity(_, _, Void) >> { sleep(11); new ResponseEntity<Void>(HttpStatus.OK) }
+        }
+        loggerService.eventQueueSize = 10
+//        loggerService.throttleDelay = 100
+
+        loggerService.init()
+
+        boolean logEventBlocked = true
+
+        when: 'log more then buffer in quick succession'
+        10.times {
+            LogEventVO logEvent = new LogEventVO()
+            logEvent.sourceUrl = it as String
+
+            loggerService.logEvent(logEvent)
+        }
+
+        then:
+        true
+//        0 * loggerService.restTemplate.postForEntity(_, _, Void) >> { sleep(11); new ResponseEntity<Void>(HttpStatus.OK) }
+
+        when:
+        Thread.start {
+
+            sleep(100)
+
+            LogEventVO logEvent = new LogEventVO()
+            logEvent.sourceUrl = 'blocked 11'
+
+            loggerService.logEvent(logEvent)
+            logEventBlocked = false
+        }
+
+        then:
+        logEventBlocked
+//        _ * loggerService.restTemplate.postForEntity(*_) >> { sleep(12); new ResponseEntity<Void>(HttpStatus.OK) }
+
+        when:
+        sleep(10000)
+
+        then: 'expect all events POSTed'
+        !logEventBlocked
+//        _ * loggerService.restTemplate.postForEntity(*_) >> { sleep(12); new ResponseEntity<Void>(HttpStatus.OK) }
+
+
+//        when:
+//        logEventBlocked = true
+//        Thread.start({
+//            loggerService.logEvent(logEvent)
+//            logEventBlocked = false
+//        })
+//
+//        then:
+//        logEventBlocked
+//        loggerService.eventQueue.size() == 9
+
+//        when:
+//        sleep(2000)
+//
+//        then:
+//        10 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
+//        !logEventBlocked
+
+//        then: 'expect all events POSTed'
+    }
+
     void 'thottle log events'() {
 
         setup:
@@ -41,22 +113,17 @@ class LoggerServiceSpec extends Specification {
 
         loggerService.init()
 
-        LogEventVO logEvent = new LogEventVO()
-        HttpHeaders headers = new HttpHeaders()
-        headers.set(HttpHeaders.USER_AGENT, logEvent.getUserAgent())
-
         when: 'log more then buffer in quick succession'
         10.times {
+            LogEventVO logEvent = new LogEventVO()
+            logEvent.sourceUrl = it as String
+
             loggerService.logEvent(logEvent)
         }
-
-        then:
-        0 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
-
-        when:
-        Thread.sleep(10 * loggerService.throttleDelay)
+        
+        sleep(10 * loggerService.throttleDelay)
 
         then: 'expect all events POSTed'
-        10 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void) >> { new ResponseEntity<Void>(HttpStatus.OK) }
+        10 * loggerService.restTemplate.postForEntity(*_) >> { new ResponseEntity<Void>(HttpStatus.OK) }
     }
 }

--- a/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
+++ b/src/test/java/au/org/ala/biocache/service/LoggerServiceSpec.groovy
@@ -1,0 +1,31 @@
+package au.org.ala.biocache.service
+
+import org.ala.client.model.LogEventVO
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.web.client.RestOperations
+import spock.lang.Specification
+
+class LoggerServiceSpec extends Specification {
+
+    void 'async log event'() {
+
+        setup:
+        LoggerRestService loggerService = new LoggerRestService()
+        loggerService.enabled = false
+        loggerService.restTemplate = Mock(RestOperations)
+
+        loggerService.init()
+
+        LogEventVO logEvent = new LogEventVO()
+        HttpHeaders headers = new HttpHeaders()
+        headers.set(HttpHeaders.USER_AGENT, logEvent.getUserAgent())
+
+        when:
+        loggerService.logEvent(logEvent)
+        Thread.sleep(1000)
+
+        then:
+        1 * loggerService.restTemplate.postForEntity(_, new HttpEntity<>(logEvent, headers), Void)
+    }
+}


### PR DESCRIPTION
Asynchronously processes the log events retrieving from a `BlockingQueue`. 

The implementation uses the ReactiveX (RxJava) library to setup a back pressure aware Flowable emitting LogEvents from the blocking queue when they become available. The subscription(Consumer) requests individual events to prevent standard buffering. 

The async logging configuration values: 
 - `logger.service.queue.size` : the queue size before blocking occurs
 - `logger.service.thread.pool` : ThreadPool asynchronously consuming log events
 - `logger.service.throttle.delay` : throttle delay between sending events to the `logger-service`


