### PR TITLE
duplicate record assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>au.org.ala</groupId>
     <artifactId>biocache-service</artifactId>
     <packaging>war</packaging>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
     <name>biocache-service</name>
     <url>https://biocache-ws.ala.org.au/ws</url>
     <description>This is a the service layer for the ALA Biocache.

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>au.org.ala</groupId>
             <artifactId>biocache-store</artifactId>
-            <version>2.6.1-SNAPSHOT</version>
+            <version>2.6.1</version>
             <exclusions>
                 <exclusion>
                     <artifactId>org.springframework</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>au.org.ala</groupId>
     <artifactId>biocache-service</artifactId>
     <packaging>war</packaging>
-    <version>2.6.0</version>
+    <version>2.6.1-SNAPSHOT</version>
     <name>biocache-service</name>
     <url>https://biocache-ws.ala.org.au/ws</url>
     <description>This is a the service layer for the ALA Biocache.

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>au.org.ala</groupId>
             <artifactId>biocache-store</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>org.springframework</artifactId>

--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -25,19 +25,23 @@ public class AssertionService {
             String userDisplayName,
             String userAssertionStatus,
             String assertionUuid,
-            String relatedRecordId
+            String relatedRecordId,
+            String relatedRecordReason
     ) {
         logger.debug("Adding assertion to:" + recordUuid + ", code:" + code + ", comment:" + comment
                 + ",userAssertionStatus: " + userAssertionStatus + ", assertionUuid: " + assertionUuid
-                + ", userId:" +userId + ", userDisplayName:" + userDisplayName);
+                + ", userId:" +userId + ", userDisplayName:" + userDisplayName +", relatedRecordId: " + relatedRecordId
+                + ", relatedRecordReason: " + relatedRecordReason);
 
         QualityAssertion qa = au.org.ala.biocache.model.QualityAssertion.apply(Integer.parseInt(code));
         qa.setComment(comment);
         if (qa.code() == AssertionCodes.USER_DUPLICATE_RECORD().code()) {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(relatedRecordId), "Related Record ID must be set for User Duplicate Record Assertion");
             Preconditions.checkArgument(!Objects.equals(recordUuid, relatedRecordId), "User Duplicate Record Assertion can not be related to itself");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(relatedRecordReason), "Duplicate record must have a reason recorded");
 
             qa.setRelatedRecordId(relatedRecordId);
+            qa.setRelatedRecordReason(relatedRecordReason);
         }
         qa.setUserId(userId);
         qa.setUserDisplayName(userDisplayName);

--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -1,0 +1,56 @@
+package au.org.ala.biocache.service;
+
+import au.org.ala.biocache.Store;
+import au.org.ala.biocache.model.QualityAssertion;
+import au.org.ala.biocache.vocab.AssertionCodes;
+import au.org.ala.biocache.vocab.AssertionStatus;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class AssertionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AssertionService.class);
+
+    public QualityAssertion addAssertion(
+            String recordUuid,
+            String code,
+            String comment,
+            String userId,
+            String userDisplayName,
+            String userAssertionStatus,
+            String assertionUuid,
+            String relatedRecordId
+    ) {
+        logger.debug("Adding assertion to:" + recordUuid + ", code:" + code + ", comment:" + comment
+                + ",userAssertionStatus: " + userAssertionStatus + ", assertionUuid: " + assertionUuid
+                + ", userId:" +userId + ", userDisplayName:" + userDisplayName);
+
+        QualityAssertion qa = au.org.ala.biocache.model.QualityAssertion.apply(Integer.parseInt(code));
+        qa.setComment(comment);
+        if (qa.code() == AssertionCodes.USER_DUPLICATE_RECORD().code()) {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(relatedRecordId), "Related Record ID must be set for User Duplicate Record Assertion");
+            Preconditions.checkArgument(!Objects.equals(recordUuid, relatedRecordId), "User Duplicate Record Assertion can not be related to itself");
+
+            qa.setRelatedRecordId(relatedRecordId);
+        }
+        qa.setUserId(userId);
+        qa.setUserDisplayName(userDisplayName);
+        if (code.equals(Integer.toString(AssertionCodes.VERIFIED().getCode()))) {
+            qa.setRelatedUuid(assertionUuid);
+            qa.setQaStatus(Integer.parseInt(userAssertionStatus));
+        } else {
+            qa.setQaStatus(AssertionStatus.QA_UNCONFIRMED());
+        }
+
+        Store.addUserAssertion(recordUuid, qa);
+
+        return qa;
+    }
+
+}

--- a/src/main/java/au/org/ala/biocache/web/AssertionController.java
+++ b/src/main/java/au/org/ala/biocache/web/AssertionController.java
@@ -117,8 +117,9 @@ public class AssertionController extends AbstractSecureController {
             @RequestParam(value = "userAssertionStatus", required = false) String userAssertionStatus,
             @RequestParam(value = "assertionUuid", required = false) String assertionUuid,
             @RequestParam(value = "relatedRecordId", required = false) String relatedRecordId,
+            @RequestParam(value = "relatedRecordReason", required = false) String relatedRecordReason,
             HttpServletResponse response) throws Exception {
-        addAssertion(recordUuid, request,apiKey, code, comment, userId, userDisplayName, userAssertionStatus, assertionUuid, relatedRecordId, response);
+        addAssertion(recordUuid, request,apiKey, code, comment, userId, userDisplayName, userAssertionStatus, assertionUuid, relatedRecordId, relatedRecordReason, response);
     }
     /**
      * Adds a bulk list of assertions.
@@ -184,11 +185,12 @@ public class AssertionController extends AbstractSecureController {
        @RequestParam(value = "userAssertionStatus", required = false) String userAssertionStatus,
        @RequestParam(value = "assertionUuid", required = false) String assertionUuid,
        @RequestParam(value = "relatedRecordId", required = false) String relatedRecordId,
+       @RequestParam(value = "relatedRecordReason", required = false) String relatedRecordReason,
         HttpServletResponse response) throws Exception {
 
         if (shouldPerformOperation(request, response)) {
             try {
-                QualityAssertion qa = assertionService.addAssertion(recordUuid, code, comment, userId, userDisplayName, userAssertionStatus, assertionUuid, relatedRecordId);
+                QualityAssertion qa = assertionService.addAssertion(recordUuid, code, comment, userId, userDisplayName, userAssertionStatus, assertionUuid, relatedRecordId, relatedRecordReason);
 
                 String server = request.getSession().getServletContext().getInitParameter("serverName");
                 response.setHeader("Location", server + "/occurrences/" + recordUuid + "/assertions/" + qa.getUuid());

--- a/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
+++ b/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
@@ -1,0 +1,136 @@
+package au.org.ala.biocache.service;
+
+import au.org.ala.biocache.Store;
+import au.org.ala.biocache.model.QualityAssertion;
+import au.org.ala.biocache.vocab.AssertionCodes;
+import au.org.ala.biocache.vocab.AssertionStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Store.class)
+public class AssertionServiceTest {
+
+    AssertionService service;
+
+    @Before
+    public void setup() {
+        service = new AssertionService();
+        mockStatic(Store.class);
+    }
+
+    @Test
+    public void testAddAssertion() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        int code = AssertionCodes.USER_ASSERTION_OTHER().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                "",
+                assertionUuid,
+                null
+        );
+
+        assertThat("Quality Assertion is returned", qualityAssertion, notNullValue());
+        assertThat("Quality Assertion has code", qualityAssertion.code(), equalTo(code));
+        assertThat("Assertion UUID is not applied because user assertion is not verified", qualityAssertion.relatedUuid(), nullValue());
+    }
+
+    @Test
+    public void testAddVerifiedAssertion() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        int userAssertionStatus = AssertionStatus.PASSED();
+        int code = AssertionCodes.VERIFIED().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                Integer.toString(userAssertionStatus),
+                assertionUuid,
+                null
+        );
+
+        assertThat("Quality Assertion is returned", qualityAssertion, notNullValue());
+        assertThat("Quality Assertion has code", qualityAssertion.code(), equalTo(code));
+        assertThat("Assertion UUID is applied because user assertion is verified", qualityAssertion.relatedUuid(), equalTo(assertionUuid));
+        assertThat("Assertion QA status is applied because user assertion is verified", qualityAssertion.qaStatus(), equalTo(userAssertionStatus));
+    }
+
+    @Test
+    public void testAddDuplicateRecordAssertion() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        String relatedRecordUuid = UUID.randomUUID().toString();
+        int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                "",
+                assertionUuid,
+                relatedRecordUuid
+        );
+
+        assertThat("Quality Assertion is returned", qualityAssertion, notNullValue());
+        assertThat("Quality Assertion has code", qualityAssertion.code(), equalTo(code));
+        assertThat("Quality Assertion has related record id", qualityAssertion.relatedRecordId(), equalTo(relatedRecordUuid));
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDuplicateRecordAssertionFailsWithNoRelatedRecordUuid() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                "",
+                assertionUuid,
+                null
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDuplicateRecordAssertionFailsWithSameRecordAsAssertion() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                "",
+                assertionUuid,
+                recordUuid
+        );
+    }
+}

--- a/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
+++ b/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
@@ -42,6 +42,7 @@ public class AssertionServiceTest {
                 "user display name",
                 "",
                 assertionUuid,
+                null,
                 null
         );
 
@@ -65,6 +66,7 @@ public class AssertionServiceTest {
                 "user display name",
                 Integer.toString(userAssertionStatus),
                 assertionUuid,
+                null,
                 null
         );
 
@@ -79,6 +81,7 @@ public class AssertionServiceTest {
         String recordUuid = UUID.randomUUID().toString();
         String assertionUuid = UUID.randomUUID().toString();
         String relatedRecordUuid = UUID.randomUUID().toString();
+        String relatedRecordReason = "same-occurence";
         int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
 
         QualityAssertion qualityAssertion = service.addAssertion(
@@ -89,7 +92,8 @@ public class AssertionServiceTest {
                 "user display name",
                 "",
                 assertionUuid,
-                relatedRecordUuid
+                relatedRecordUuid,
+                relatedRecordReason
         );
 
         assertThat("Quality Assertion is returned", qualityAssertion, notNullValue());
@@ -112,14 +116,17 @@ public class AssertionServiceTest {
                 "user display name",
                 "",
                 assertionUuid,
+                null,
                 null
         );
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAddDuplicateRecordAssertionFailsWithSameRecordAsAssertion() {
+    public void testAddDuplicateRecordAssertionFailsWithNoRelatedReason() {
         String recordUuid = UUID.randomUUID().toString();
         String assertionUuid = UUID.randomUUID().toString();
+        String relatedRecordUuid = UUID.randomUUID().toString();
+        String relatedRecordReason = "";
         int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
 
         QualityAssertion qualityAssertion = service.addAssertion(
@@ -130,7 +137,33 @@ public class AssertionServiceTest {
                 "user display name",
                 "",
                 assertionUuid,
-                recordUuid
+                relatedRecordUuid,
+                relatedRecordReason
+        );
+
+        assertThat("Quality Assertion is returned", qualityAssertion, notNullValue());
+        assertThat("Quality Assertion has code", qualityAssertion.code(), equalTo(code));
+        assertThat("Quality Assertion has related record id", qualityAssertion.relatedRecordId(), equalTo(relatedRecordUuid));
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDuplicateRecordAssertionFailsWithSameRecordAsAssertion() {
+        String recordUuid = UUID.randomUUID().toString();
+        String assertionUuid = UUID.randomUUID().toString();
+        String relatedRecordReason = "same-occurence";
+        int code = AssertionCodes.USER_DUPLICATE_RECORD().code();
+
+        QualityAssertion qualityAssertion = service.addAssertion(
+                recordUuid,
+                Integer.toString(code),
+                "Comment",
+                "userId",
+                "user display name",
+                "",
+                assertionUuid,
+                recordUuid,
+                relatedRecordReason
         );
     }
 }


### PR DESCRIPTION
1. Changed Biocache-service to add related record id, and related reason for `duplicate record `issue.
2. Changed to use Biocache-store-2.6.1 so that above mentioned fields can be saved.
3. `AssertionService` is created to wrap the add assertion action