### PR TITLE
expand dq profile only when it's not yet formatted

### DIFF
--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -188,12 +188,10 @@ public class QueryFormatUtils {
             if (StringUtils.isNotEmpty(spatialQuery)) {
                 addFormattedFq(new String[] { spatialQuery }, searchParams);
             }
+            updateQualityProfileContext(searchParams);
         }
 
         updateQueryContext(searchParams);
-
-        updateQualityProfileContext(searchParams);
-
         return fqMaps;
     }
 


### PR DESCRIPTION
See issue https://github.com/AtlasOfLivingAustralia/biocache-service/issues/571

with this change:
1. when `searchParams.getFormattedQuery()` is empty, it gets expanded for the first time
2. once it's expanded, `searchParams.getFormattedQuery()` not empty so it will only be expanded when` forceQueryFormat == true`
3. when `forceQueryFormat`, formatFq will be set to null so dq profile only expanded once.

![code](https://user-images.githubusercontent.com/61677987/112261825-ab457f00-8cc0-11eb-9b24-9fcb381866f5.jpg)
