### PR TITLE
replaced searchDAO.findByFulltext with queryFormatUtils.formatSearchQ…

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/QidCacheDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/QidCacheDAOImpl.java
@@ -19,6 +19,7 @@ import au.org.ala.biocache.model.Qid;
 import au.org.ala.biocache.service.DataQualityService;
 import au.org.ala.biocache.util.QidMissingException;
 import au.org.ala.biocache.util.QidSizeException;
+import au.org.ala.biocache.util.QueryFormatUtils;
 import au.org.ala.biocache.util.SpatialUtils;
 import com.googlecode.ehcache.annotations.Cacheable;
 import org.apache.log4j.Logger;
@@ -90,6 +91,9 @@ public class QidCacheDAOImpl implements QidCacheDAO {
 
     @Inject
     private DataQualityService dataQualityService;
+
+    @Inject
+    protected QueryFormatUtils queryFormatUtils;
 
     /**
      * in memory store of params
@@ -461,10 +465,10 @@ public class QidCacheDAOImpl implements QidCacheDAO {
             if (bbox != null && bbox.equals("true")) {
                 bb = searchDAO.getBBox(requestParams);
             } else {
-                //get a formatted Q by running a query
                 requestParams.setPageSize(0);
                 requestParams.setFacet(false);
-                searchDAO.findByFulltext(requestParams);
+                //get a formatted Q
+                queryFormatUtils.formatSearchQuery(requestParams);
             }
 
             //store the title if necessary


### PR DESCRIPTION
…uery since the only purpose to call find is to format the request params

This is for issue https://github.com/AtlasOfLivingAustralia/biocache-service/issues/579

Replaced `searchDAO.findByFulltext(requestParams) `with `queryFormatUtils.formatSearchQuery(requestParams)` since its only purpose is to format the `requestParams`

below are the 2 functions `findByFulltext()` calls, you can see only in `queryFormatUtils.formatSearchQuery` requestParams is changed.

![1](https://user-images.githubusercontent.com/61677987/113070059-69ab5b80-920d-11eb-92ad-2915d63dfce4.jpg)

![2](https://user-images.githubusercontent.com/61677987/113069962-349f0900-920d-11eb-8e2c-cc0e548b2350.jpg)
