### PR TITLE
239 duplicate services

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -3724,7 +3724,7 @@ public class SearchDAOImpl implements SearchDAO {
         return null;
     }
 
-    private SolrQuery createHeatmapQuery(SpatialSearchRequestParams searchParams, Double minx, Double miny, Double maxx, Double maxy, boolean isGrid) {
+private SolrQuery createHeatmapQuery(SpatialSearchRequestParams searchParams, Double minx, Double miny, Double maxx, Double maxy, boolean isGrid) throws QidMissingException {
 
         queryFormatUtils.formatSearchQuery(searchParams, true);
         SolrQuery solrQuery = new SolrQuery();

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -3725,6 +3725,8 @@ public class SearchDAOImpl implements SearchDAO {
     }
 
     private SolrQuery createHeatmapQuery(SpatialSearchRequestParams searchParams, Double minx, Double miny, Double maxx, Double maxy, boolean isGrid) {
+
+        queryFormatUtils.formatSearchQuery(searchParams, true);
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setRequestHandler("standard");
         solrQuery.set("facet.heatmap", spatialField);

--- a/src/main/java/au/org/ala/biocache/dto/DuplicateRecordDetails.java
+++ b/src/main/java/au/org/ala/biocache/dto/DuplicateRecordDetails.java
@@ -37,19 +37,28 @@ public class DuplicateRecordDetails {
     public DuplicateRecordDetails() {
     }
 
-    ;
-
     public DuplicateRecordDetails(SolrDocument d) {
         this.id = (String) d.getFieldValue(OccurrenceIndex.ID);
-        this.status = (String) d.getFieldValue(OccurrenceIndex.DUPLICATE_STATUS);
+
+        Object duplicateStatusIndex = d.getFieldValue(OccurrenceIndex.DUPLICATE_STATUS);
+
+        if (duplicateStatusIndex instanceof java.util.List){
+            this.status = (String) ((java.util.List) duplicateStatusIndex).get(0);
+        } else {
+            this.status = (String) duplicateStatusIndex;
+        }
 
         if ("ASSOCIATED".equals(status)) {
             // is duplicate
             this.dupTypes = new ArrayList();
-            for (Object dupType : d.getFieldValues(OccurrenceIndex.DUPLICATE_REASONS)) {
-                dupTypes.add(dupType.toString());
+
+            Object isDuplicateOfIndex = d.getFieldValue(OccurrenceIndex.DUPLICATE_OF);
+
+            if (isDuplicateOfIndex instanceof java.util.List){
+                this.duplicateOf = (String) ((java.util.List) isDuplicateOfIndex).get(0);
+            } else {
+                this.duplicateOf = (String) isDuplicateOfIndex;
             }
-            this.duplicateOf = (String) d.getFieldValue(OccurrenceIndex.DUPLICATE_OF);
         }
 
         taxonConceptLsid = (String) d.getFieldValue(OccurrenceIndex.TAXON_CONCEPT_ID);
@@ -59,15 +68,19 @@ public class DuplicateRecordDetails {
         point0_0001 = (String) d.getFieldValue(PointType.POINT_0001.getLabel());
         latLong = (String) d.getFieldValue(OccurrenceIndex.LAT_LNG);
         rawScientificName = (String) d.getFieldValue(OccurrenceIndex.RAW_TAXON_NAME);
-        collector = (String) d.getFieldValue(OccurrenceIndex.COLLECTOR);
+
+//        collector = (String) d.getFieldValue(OccurrenceIndex.COLLECTOR);
+
+
+
         recordNumber = (String) d.getFieldValue(OccurrenceIndex.RECORD_NUMBER);
         catalogueNumber = (String) d.getFieldValue(OccurrenceIndex.CATALOGUE_NUMBER);
         precision = null; // This is not in pipelines (Integer) d.getFieldValue(OccurrenceIndex.PRECISION);
 
-        // depricated fields for backward compatability
+        // deprecated fields for backward compatibility
         rowKey = (String) d.getFieldValue(OccurrenceIndex.ID);
         uuid = (String) d.getFieldValue(OccurrenceIndex.ID);
-        druid = (String) d.getFieldValue(OccurrenceIndex.ID);
+        druid = (String) d.getFieldValue(OccurrenceIndex.DATA_RESOURCE_UID);
     }
 
     public String getId() {

--- a/src/main/java/au/org/ala/biocache/dto/DuplicateRecordDetails.java
+++ b/src/main/java/au/org/ala/biocache/dto/DuplicateRecordDetails.java
@@ -3,17 +3,23 @@ package au.org.ala.biocache.dto;
 import org.apache.solr.common.SolrDocument;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
  * Merged from biocache-store
  */
 public class DuplicateRecordDetails {
+
+    public static final String ASSOCIATED = "ASSOCIATED";
+    public static final String REPRESENTATIVE = "REPRESENTATIVE";
+
     String id;
     String status;
     String duplicateOf;
     List<DuplicateRecordDetails> duplicates;
     List<String> dupTypes;
+    List<String> justification;
 
     // fields that may be used to determine associated records
     String taxonConceptLsid;
@@ -27,15 +33,16 @@ public class DuplicateRecordDetails {
     String collector;
     String recordNumber;
     String catalogueNumber;
-    Integer precision;
+    Double precision;
+    Double coordinateUncertaintyInMeters;
 
-    // depricated fields for backward compatability
+    // deprecated fields for backward compatibility
     String rowKey;
     String uuid;
     String druid;
 
-    public DuplicateRecordDetails() {
-    }
+
+    public DuplicateRecordDetails() {}
 
     public DuplicateRecordDetails(SolrDocument d) {
         this.id = (String) d.getFieldValue(OccurrenceIndex.ID);
@@ -48,17 +55,19 @@ public class DuplicateRecordDetails {
             this.status = (String) duplicateStatusIndex;
         }
 
-        if ("ASSOCIATED".equals(status)) {
+        if (ASSOCIATED.equals(status)) {
             // is duplicate
             this.dupTypes = new ArrayList();
 
             Object isDuplicateOfIndex = d.getFieldValue(OccurrenceIndex.DUPLICATE_OF);
-
             if (isDuplicateOfIndex instanceof java.util.List){
                 this.duplicateOf = (String) ((java.util.List) isDuplicateOfIndex).get(0);
             } else {
                 this.duplicateOf = (String) isDuplicateOfIndex;
             }
+
+            Collection justificationIndex = d.getFieldValues(OccurrenceIndex.DUPLICATE_JUSTIFICATION);
+            this.justification = new ArrayList<>(justificationIndex);
         }
 
         taxonConceptLsid = (String) d.getFieldValue(OccurrenceIndex.TAXON_CONCEPT_ID);
@@ -68,14 +77,11 @@ public class DuplicateRecordDetails {
         point0_0001 = (String) d.getFieldValue(PointType.POINT_0001.getLabel());
         latLong = (String) d.getFieldValue(OccurrenceIndex.LAT_LNG);
         rawScientificName = (String) d.getFieldValue(OccurrenceIndex.RAW_TAXON_NAME);
-
-//        collector = (String) d.getFieldValue(OccurrenceIndex.COLLECTOR);
-
-
-
+        collector = (String) d.getFieldValue(OccurrenceIndex.RAW_RECORDED_BY);
         recordNumber = (String) d.getFieldValue(OccurrenceIndex.RECORD_NUMBER);
         catalogueNumber = (String) d.getFieldValue(OccurrenceIndex.CATALOGUE_NUMBER);
-        precision = null; // This is not in pipelines (Integer) d.getFieldValue(OccurrenceIndex.PRECISION);
+        precision =  (Double) d.getFieldValue(OccurrenceIndex.COORDINATE_PRECISION);
+        coordinateUncertaintyInMeters = (Double) d.getFieldValue(OccurrenceIndex.COORDINATE_UNCERTAINTY);
 
         // deprecated fields for backward compatibility
         rowKey = (String) d.getFieldValue(OccurrenceIndex.ID);
@@ -91,11 +97,11 @@ public class DuplicateRecordDetails {
         this.id = id;
     }
 
-    public Integer getPrecision() {
+    public Double getPrecision() {
         return precision;
     }
 
-    public void setPrecision(Integer precision) {
+    public void setPrecision(Double precision) {
         this.precision = precision;
     }
 
@@ -241,5 +247,21 @@ public class DuplicateRecordDetails {
 
     public void setDruid(String druid) {
         this.druid = druid;
+    }
+
+    public List<String> getJustification() {
+        return justification;
+    }
+
+    public void setJustification(List<String> justification) {
+        this.justification = justification;
+    }
+
+    public Double getCoordinateUncertaintyInMeters() {
+        return coordinateUncertaintyInMeters;
+    }
+
+    public void setCoordinateUncertaintyInMeters(Double coordinateUncertaintyInMeters) {
+        this.coordinateUncertaintyInMeters = coordinateUncertaintyInMeters;
     }
 }

--- a/src/main/java/au/org/ala/biocache/dto/FacetThemes.java
+++ b/src/main/java/au/org/ala/biocache/dto/FacetThemes.java
@@ -183,7 +183,7 @@ public class FacetThemes {
                 new FacetDTO(OccurrenceIndex.PHYLUM, "index", null, null, null),
                 new FacetDTO(OccurrenceIndex.KINGDOM, "index", null, null, null),
                 new FacetDTO(OccurrenceIndex.SPECIES_GROUP, "index", null, null, null),
-                new FacetDTO(OccurrenceIndex.RANK, "count", null, null, null),
+                new FacetDTO(OccurrenceIndex.TAXON_RANK, "count", null, null, null),
                 new FacetDTO(OccurrenceIndex.SPECIES_HABITATS, "count", null, null, null)));
 
         allThemes.add(new FacetTheme("Geospatial",

--- a/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
+++ b/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
@@ -43,6 +43,7 @@ public class OccurrenceIndex {
 
     public static final String TAXON_NAME = "scientificName";
     public static final String RAW_TAXON_NAME = "raw_scientificName";
+    public static final String RAW_RECORDED_BY = "raw_recordedBy";
     public static final String RANK = "taxonRank";
     public static final String LATITUDE = "decimalLatitude";
     public static final String LONGITUDE = "decimalLongitude";
@@ -68,7 +69,7 @@ public class OccurrenceIndex {
     public static final String OCCURRENCE_DATE = "eventDate";
     public static final String RECORD_NUMBER = "recordNumber";
     public static final String CATALOGUE_NUMBER = "catalogNumber";
-    public static final String PRECISION = "precision"; //TODO: not in pipeline
+    public static final String COORDINATE_PRECISION = "coordinatePrecision";
     public static final String RANK_ID = "rankID";
     protected static final Logger logger = Logger.getLogger(OccurrenceIndex.class);
 
@@ -191,21 +192,21 @@ public class OccurrenceIndex {
     String dataResourceName;
     @Field("assertions")
     String[] assertions;
-    @Field("user_assertions")
+    @Field("userAssertions")
     String hasUserAssertions;
-    @Field("species_group")
+    @Field("speciesGroup")
     String[] speciesGroups;
     @Field("imageID")
     String image;
     @Field("imageIDs")
     String[] images;
-    //@Field("geospatial_kosher")
+    @Field("spatiallyValid")
     Boolean geospatialKosher;
     //@Field("taxonomic_kosher")
     String taxonomicKosher;
     @Field("recordedBy")
     String[] collector;
-    //@Field("collectors")
+    @Field("recordedBy")
     String[] collectors;
     //extra raw record fields
     @Field("raw_scientificName")
@@ -235,22 +236,22 @@ public class OccurrenceIndex {
     String[] multimedia;
     @Field("license")
     String license;
-    //@Field("raw_identificationVerificationStatus")
+    @Field("identificationVerificationStatus")
     String identificationVerificationStatus;
     //conservation status field
-    //@Field("aust_conservation")
+    @Field("countryConservation")
     String austConservation;
-    //@Field("state_conservation")
+    @Field("stateConservation")
     String stateConservation;
     @Field("sensitive")
     String sensitive;
     //AVH extra fields
-    //@Field("raw_recordNumber")
+    @Field("recordNumber")
     String recordNumber;
     //For harvesting of images into the BIE
-    //@Field("raw_occurrenceDetails")
+    @Field("references")
     String occurrenceDetails;
-    //@Field("raw_rights")
+    @Field("rights")
     String rights;
     //@Field("photographer_s")
     String photographer;
@@ -306,6 +307,7 @@ public class OccurrenceIndex {
     public static final String DUPLICATE_OF = "isDuplicateOf";
     public static final String DUPLICATE_STATUS = "duplicateStatus";
     public static final String DUPLICATE_REASONS = "duplicateType";
+    public static final String DUPLICATE_JUSTIFICATION = "duplicateJustification";
     public static final String ID = "id";
 
     public static final String SPECIES_SUBGROUP = "speciesSubgroup";

--- a/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
+++ b/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
@@ -31,20 +31,19 @@ import java.util.Map;
  */
 public class OccurrenceIndex {
 
-    final static public String ROW_KEY = "id";
+    protected static final Logger logger = Logger.getLogger(OccurrenceIndex.class);
+
     final static public String IMAGES = "imageIDs";
     final static public String SOUNDS = "soundIDs";
     //final static public String GEOSPATIAL_KOSHER = "geospatial_kosher"; // Not in pipelines
     final static public String COUNTRY = "country";
     final static public String STATE = "stateProvince";
     final static public String PROVENANCE = "provenance";
-
     public static final String OCCURRENCE_YEAR_INDEX_FIELD = "occurrenceYear";
-
     public static final String TAXON_NAME = "scientificName";
     public static final String RAW_TAXON_NAME = "raw_scientificName";
     public static final String RAW_RECORDED_BY = "raw_recordedBy";
-    public static final String RANK = "taxonRank";
+    public static final String TAXON_RANK = "taxonRank";
     public static final String LATITUDE = "decimalLatitude";
     public static final String LONGITUDE = "decimalLongitude";
     public static final String DATA_RESOURCE_NAME = "dataResourceName";
@@ -63,18 +62,12 @@ public class OccurrenceIndex {
     public static final String OUTLIER_LAYER = "outlierLayer";
     public static final String OUTLIER_LAYER_COUNT = "outlierLayerCount";
     public static final String TAXONOMIC_ISSUE = "taxonomicIssues";
-    public static final String FAMILYID = "familyID";
-    public static final String KINGDOMID = "kingdomID";
-    public static final String PHYLUMID = "phylumID";
     public static final String OCCURRENCE_DATE = "eventDate";
     public static final String RECORD_NUMBER = "recordNumber";
     public static final String CATALOGUE_NUMBER = "catalogNumber";
     public static final String COORDINATE_PRECISION = "coordinatePrecision";
-    public static final String RANK_ID = "rankID";
-    protected static final Logger logger = Logger.getLogger(OccurrenceIndex.class);
-
+    public static final String TAXON_RANK_ID = "taxonRankID";
     public static final String TAXON_CONCEPT_ID = "taxonConceptID";
-    public static final String SUBSPECIESID = "subspeciesID";
     public static final String SPECIESID = "speciesID";
     public static final String GENUSID = "genusID";
     public static final String DATA_PROVIDER_NAME = "dataProviderName";
@@ -124,7 +117,7 @@ public class OccurrenceIndex {
     String vernacularName;
     @Field("taxonRank")
     String taxonRank;
-    @Field("rankID")
+    @Field("taxonRankID")
     Integer taxonRankID;
     @Field("raw_countryCode")
     String raw_countryCode;

--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -262,27 +262,6 @@ public class QueryFormatUtils {
         }
     }
 
-    public Qid extractQid(String query){
-
-        if (query == null){
-            return null;
-        }
-
-        Qid qid = null;
-        Matcher matcher = qidPattern.matcher(query);
-        while (matcher.find()) {
-            String value = matcher.group();
-            try {
-                String qidValue = SearchUtils.stripEscapedQuotes(value.substring(4));
-                qid = qidCacheDao.get(qidValue);
-            } catch (Exception e){
-                logger.error("Unable to retrieve QID from query " + query, e);
-            }
-        }
-
-        return qid;
-    }
-
     /**
      * Replace query qid value with actual query.
      *

--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -73,10 +73,7 @@ public class QueryFormatUtils {
     protected Pattern speciesListPattern = Pattern.compile("(^|\\s|\"|\\(|\\[|'|-)species_list:\"?(dr[0-9]*)\"?");
     protected Pattern urnPattern = Pattern.compile("\\burn:[a-zA-Z0-9\\.:-]*");
     protected Pattern httpPattern = Pattern.compile("http:[a-zA-Z0-9/\\.:\\-_]*");
-    protected Pattern spacesPattern = Pattern.compile("[^\\s\"\\(\\)\\[\\]{}']+|\"[^\"]*\"|'[^']*'");
     protected Pattern uidPattern = Pattern.compile("(?:[\"]*)?((?:[a-z_]*_uid:)|(?:[a-zA-Z]*Uid:))(\\w*)(?:[\"]*)?");
-    protected Pattern uidPattern10 = Pattern.compile("(?:[\"]*)?([a-z_]*_uid:)(\\w*)(?:[\"]*)?");
-    protected Pattern uidPattern20 = Pattern.compile("(?:[\"]*)?([a-zA-Z]*Uid:)(\\w*)(?:[\"]*)?");
     protected Pattern spatialPattern = Pattern.compile(spatialField + ":\"Intersects\\([a-zA-Z=\\-\\s0-9\\.\\,():]*\\)\\\"");
     protected Pattern qidPattern = QidCacheDAO.qidPattern;//Pattern.compile("qid:[0-9]*");
     protected Pattern termPattern = Pattern.compile("([a-zA-z_]+?):((\".*?\")|(\\\\ |[^: \\)\\(])+)"); // matches foo:bar, foo:"bar bash" & foo:bar\ bash
@@ -109,7 +106,7 @@ public class QueryFormatUtils {
         this.maxBooleanClauses = maxBooleanClauses;
     }
 
-    public Map[] formatSearchQuery(SpatialSearchRequestParams searchParams) {
+    public Map[] formatSearchQuery(SpatialSearchRequestParams searchParams) throws QidMissingException {
         return formatSearchQuery(searchParams, false);
     }
 
@@ -123,7 +120,7 @@ public class QueryFormatUtils {
      * @return
      */
 //    @Cacheable(cacheName = "formatSearchQuery")
-    public Map[] formatSearchQuery(SpatialSearchRequestParams searchParams, boolean forceQueryFormat) {
+    public Map[] formatSearchQuery(SpatialSearchRequestParams searchParams, boolean forceQueryFormat) throws QidMissingException{
         Map<String, Facet> activeFacetMap = new HashMap();
         Map<String, List<Facet>> activeFacetObj = new HashMap<>();
         Map[] fqMaps = {activeFacetMap, activeFacetObj};
@@ -271,7 +268,7 @@ public class QueryFormatUtils {
      * @param searchParams
      * @return
      */
-    private String [] formatQid(String query, SpatialSearchRequestParams searchParams) {
+    private String [] formatQid(String query, SpatialSearchRequestParams searchParams) throws QidMissingException{
         String q = query;
         String displayString = query;
         if (query != null && query.contains("qid:")) {
@@ -308,10 +305,10 @@ public class QueryFormatUtils {
                         }
 
                         count = count + 1;
+                    } else {
+                        throw new QidMissingException("Unrecognised QID: " + searchParams.getQ()    );
                     }
                 } catch (NumberFormatException e) {
-                    logger.error(e.getMessage(), e);
-                } catch (QidMissingException e) {
                     logger.error(e.getMessage(), e);
                 }
             }
@@ -678,7 +675,7 @@ public class QueryFormatUtils {
      * @param current String [] { displayString, formattedQuery } to update.
      * @return true iff this is a spatial query.
      */
-    private boolean formatSpatial(String [] current) {
+    private boolean formatSpatial(String [] current) throws QidMissingException {
         if(current == null || current.length < 2 || current[1] == null){
             return false;
         }
@@ -809,7 +806,7 @@ public class QueryFormatUtils {
      * @param searchParams The search parameters.
      * @return String [] { displayString, formattedQuery }
      */
-    public String [] formatQueryTerm(String query, SpatialSearchRequestParams searchParams) {
+    public String [] formatQueryTerm(String query, SpatialSearchRequestParams searchParams) throws QidMissingException {
         String [] formatted = formatQid(query, searchParams);
 
         formatTerms(formatted);

--- a/src/main/java/au/org/ala/biocache/web/DuplicationController.java
+++ b/src/main/java/au/org/ala/biocache/web/DuplicationController.java
@@ -44,8 +44,6 @@ public class DuplicationController {
      * Logger initialisation
      */
     private final static Logger logger = Logger.getLogger(DuplicationController.class);
-    public static final String REPRESENTATIVE = "REPRESENTATIVE";
-    public static final String ASSOCIATED = "ASSOCIATED";
     /**
      * Fulltext search DAO
      */
@@ -84,16 +82,15 @@ public class DuplicationController {
 
             DuplicateRecordDetails drd = new DuplicateRecordDetails(sd);
 
-            if (REPRESENTATIVE.equals(drd.getStatus())) {
+            if (DuplicateRecordDetails.REPRESENTATIVE.equals(drd.getStatus())) {
                 // is representative id
                 List<DuplicateRecordDetails> dups = new ArrayList<>();
                 SolrDocumentList list = searchDuplicates(DUPLICATE_OF, guid);
-                for (int i = 0; i < list.size(); i++) {
-                    SolrDocument d = list.get(i);
+                for (SolrDocument d: list) {
                     dups.add(new DuplicateRecordDetails(d));
                 }
                 drd.setDuplicates(dups);
-            } else if (ASSOCIATED.equals(drd.getStatus())) {
+            } else if (DuplicateRecordDetails.ASSOCIATED.equals(drd.getStatus())) {
                 // is duplicate id, return result for the representative id
                 return getDuplicateStatsForGuid(drd.getDuplicateOf());
             } else {
@@ -117,6 +114,7 @@ public class DuplicationController {
                 DUPLICATE_OF,
                 DUPLICATE_REASONS,
                 DUPLICATE_STATUS,
+                DUPLICATE_JUSTIFICATION,
                 TAXON_CONCEPT_ID,
                 PointType.POINT_1.getLabel(),
                 PointType.POINT_01.getLabel(),

--- a/src/main/java/au/org/ala/biocache/web/ExploreController.java
+++ b/src/main/java/au/org/ala/biocache/web/ExploreController.java
@@ -336,7 +336,7 @@ public class ExploreController {
      * @param facetValue
      */
     private void addFacetFilterToQuery(SpatialSearchRequestParams requestParams, String facetName, String facetValue) {
-        String rankId = OccurrenceIndex.RANK_ID;
+        String rankId = OccurrenceIndex.TAXON_RANK_ID;
 
         List<String> fqs = new ArrayList<>();
 

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -1431,11 +1431,10 @@ public class OccurrenceController extends AbstractSecureController {
         SpatialSearchRequestParams idRequest = new SpatialSearchRequestParams();
         idRequest.setQ(OccurrenceIndex.ID + ":\"" + uuid + "\"");
         idRequest.setFacet(false);
-//        idRequest.setFl(StringUtils.join(indexDao.getIndexedFieldsMap().keySet(), ","));
         idRequest.setFl("*");
 
         SolrDocumentList sdl = searchDAO.findByFulltext(idRequest);
-        if (sdl.size() == 0) {
+        if (sdl.isEmpty()) {
             return new HashMap();
         }
 
@@ -1623,14 +1622,37 @@ public class OccurrenceController extends AbstractSecureController {
     Map fullRecord(String prefix, SolrDocument sd) {
         Map fullRecord = new HashMap();
         fullRecord.put("rowKey",  sd.getFieldValue(ID)); // Use the processed ID for compatability
-
+        fullRecord.put("uuid",  sd.getFieldValue(ID));
         // au.org.ala.biocache.model.Occurrence
         Map occurrence = new HashMap();
         fullRecord.put("occurrence", occurrence);
         add(sd, occurrence, "occurrenceID", prefix);
         add(sd, occurrence, "accessRights", prefix);
         add(sd, occurrence, "associatedMedia", prefix);
-        add(sd, occurrence, "associatedOccurrences", prefix);
+
+        if (!StringUtils.isEmpty(prefix)) {
+            // add raw content
+            add(sd, occurrence, "associatedOccurrences", prefix);
+        } else {
+
+            List duplicateStatuses = (List) sd.get("duplicateStatus");
+            if (duplicateStatuses != null && !duplicateStatuses.isEmpty()) {
+                String duplicateStatus = (String) duplicateStatuses.get(0);
+                // and duplicate details
+
+                occurrence.put("duplicateStatus", duplicateStatus);
+                if ("REPRESENTATIVE".equals(duplicateStatus)){
+                    occurrence.put("duplicationStatus", "R");  //backwards compatibility
+                    List<String> associatedOccurrences = (List) sd.get("isRepresentativeOf");
+                    occurrence.put("associatedOccurrences", String.join("|", associatedOccurrences));
+                } else if ("ASSOCIATED".equals(duplicateStatus)){
+                    occurrence.put("duplicationStatus", "D");  //backwards compatibility
+                    List<String> associatedOccurrences = (List) sd.get("isDuplicateOf");
+                    occurrence.put("associatedOccurrences", String.join("|", associatedOccurrences));
+                }
+            }
+        }
+
         add(sd, occurrence, "associatedReferences", prefix);
         add(sd, occurrence, "associatedSequences", prefix);
         add(sd, occurrence, "associatedTaxa", prefix);
@@ -1648,9 +1670,7 @@ public class OccurrenceController extends AbstractSecureController {
         add(sd, occurrence, "establishmentMeans", prefix);
         add(sd, occurrence, "fieldNotes", prefix);
         add(sd, occurrence, "fieldNumber", prefix);
-//        occurrence.put("identifier", "");  // Not in pipeline
         add(sd, occurrence, "individualCount", prefix);
-//        occurrence.put("individualID", "");  // Not in pipeline
         add(sd, occurrence, "informationWithheld", prefix);   //used for sensitive data information
         add(sd, occurrence, "institutionCode", prefix);
         add(sd, occurrence, "institutionID", prefix);
@@ -1658,7 +1678,6 @@ public class OccurrenceController extends AbstractSecureController {
         add(sd, occurrence, "license", prefix);
         add(sd, occurrence, "lifeStage", prefix);
         add(sd, occurrence, "modified", prefix);
-//        occurrence.put("occurrenceAttributes", "");  // Not in pipeline
         add(sd, occurrence, "occurrenceAttributes", prefix);
         add(sd, occurrence, "occurrenceDetails", prefix);
         add(sd, occurrence, "occurrenceRemarks", prefix);
@@ -1708,13 +1727,13 @@ public class OccurrenceController extends AbstractSecureController {
         //custom fields
         add(sd, occurrence, "videoIDs", prefix);
         add(sd, occurrence, "interactions", prefix);
-
-        add(sd, occurrence, "duplicateStatus", prefix);
-        add(sd, occurrence, "duplicateType", prefix);
         //Store the conservation status
         add(sd, occurrence, "countryConservation", prefix);
         add(sd, occurrence, "stateConservation", prefix);
         add(sd, occurrence, "globalConservation", prefix);
+        add(sd, occurrence, "stateInvasive", prefix);
+        add(sd, occurrence, "countryInvasive", prefix);
+
         add(sd, occurrence, "outlierLayer", prefix);
         add(sd, occurrence, "photographer", prefix);
         // support for schema change

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -65,6 +65,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+import static au.org.ala.biocache.dto.DuplicateRecordDetails.ASSOCIATED;
+import static au.org.ala.biocache.dto.DuplicateRecordDetails.REPRESENTATIVE;
 import static au.org.ala.biocache.dto.OccurrenceIndex.*;
 
 /**
@@ -1635,20 +1637,23 @@ public class OccurrenceController extends AbstractSecureController {
             add(sd, occurrence, "associatedOccurrences", prefix);
         } else {
 
-            List duplicateStatuses = (List) sd.get("duplicateStatus");
-            if (duplicateStatuses != null && !duplicateStatuses.isEmpty()) {
-                String duplicateStatus = (String) duplicateStatuses.get(0);
-                // and duplicate details
-
-                occurrence.put("duplicateStatus", duplicateStatus);
-                if ("REPRESENTATIVE".equals(duplicateStatus)){
-                    occurrence.put("duplicationStatus", "R");  //backwards compatibility
-                    List<String> associatedOccurrences = (List) sd.get("isRepresentativeOf");
+            String duplicateStatus = (String) sd.get("duplicateStatus");
+            occurrence.put("duplicateStatus", duplicateStatus);
+            if (REPRESENTATIVE.equals(duplicateStatus)){
+                occurrence.put("duplicationStatus", "R");  //backwards compatibility
+                List<String> associatedOccurrences = (List) sd.get("isRepresentativeOf");
+                if (associatedOccurrences != null) {
                     occurrence.put("associatedOccurrences", String.join("|", associatedOccurrences));
-                } else if ("ASSOCIATED".equals(duplicateStatus)){
-                    occurrence.put("duplicationStatus", "D");  //backwards compatibility
-                    List<String> associatedOccurrences = (List) sd.get("isDuplicateOf");
+                } else {
+                    occurrence.put("associatedOccurrences", "");
+                }
+            } else if (ASSOCIATED.equals(duplicateStatus)){
+                occurrence.put("duplicationStatus", "D");  //backwards compatibility
+                List<String> associatedOccurrences = (List) sd.get("isDuplicateOf");
+                if (associatedOccurrences != null) {
                     occurrence.put("associatedOccurrences", String.join("|", associatedOccurrences));
+                } else {
+                    occurrence.put("associatedOccurrences", "");
                 }
             }
         }

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -1454,7 +1454,9 @@ public class WMSController extends AbstractSecureController{
         double[] bbox = reprojectBBox(tilebbox, srs);
 
         boolean isGrid = vars.colourMode.equals("grid");
-        logger.info("vars.colourMode = " + vars.colourMode);
+        if (logger.isDebugEnabled()) {
+            logger.debug("vars.colourMode = " + vars.colourMode);
+        }
 
         // add a buffer of 10px
         // add buffer
@@ -2707,7 +2709,9 @@ public class WMSController extends AbstractSecureController{
             return null;
         }
 
-        logger.info("Image width:" + tileWidthInPx + ", height:" + tileHeightInPx);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Image width:" + tileWidthInPx + ", height:" + tileHeightInPx);
+        }
 
         ImgObj imgObj = ImgObj.create( (int)(tileWidthInPx ), (int) (tileHeightInPx ));
 
@@ -2766,12 +2770,16 @@ public class WMSController extends AbstractSecureController{
                 }
             }
 
-            logger.info("Rows:" + numberOfRows + ", columns:" + nofOfColumns);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Rows:" + numberOfRows + ", columns:" + nofOfColumns);
+            }
 
             float cellWidth = tileWidthInPx / (float) nofOfColumns;
             float cellHeight = tileHeightInPx / (float) numberOfRows;
 
-            logger.info("cellWidth:" + cellWidth + ", cellHeight:" + cellHeight);
+            if (logger.isDebugEnabled()) {
+                logger.debug("cellWidth:" + cellWidth + ", cellHeight:" + cellHeight);
+            }
 
             Color oColour = Color.decode(outlineColour);
 

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -1494,6 +1494,7 @@ public class WMSController extends AbstractSecureController{
         if (tile != null && tile.g != null) {
             tile.g.dispose();
             try (ServletOutputStream outStream = response.getOutputStream();) {
+                response.setContentType("image/png");
                 ImageIO.write(tile.img, "png", outStream);
                 outStream.flush();
             } catch (Exception e) {

--- a/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/FilterQueryParserTest.java
@@ -6,10 +6,7 @@ import au.org.ala.biocache.dto.FacetThemes;
 import au.org.ala.biocache.dto.SpatialSearchRequestParams;
 import au.org.ala.biocache.service.DataQualityService;
 import au.org.ala.biocache.service.SpeciesLookupService;
-import au.org.ala.biocache.util.CollectionsCache;
-import au.org.ala.biocache.util.QueryFormatUtils;
-import au.org.ala.biocache.util.RangeBasedFacets;
-import au.org.ala.biocache.util.SearchUtils;
+import au.org.ala.biocache.util.*;
 import au.org.ala.biocache.util.solr.FieldMappingUtil;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
@@ -170,7 +167,7 @@ public class FilterQueryParserTest {
     }
 */
     @Test
-    public void testFacetMap() {
+    public void testFacetMap() throws QidMissingException  {
 
         final LinkedHashMap<String, String> collections =  new LinkedHashMap<String, String>();
         collections.put("co10", "found co10");
@@ -247,7 +244,7 @@ public class FilterQueryParserTest {
     }
 
     @Test
-    public void testFqFormat() {
+    public void testFqFormat() throws QidMissingException {
 
         Mockito.when(fieldMappingUtil.translateFieldName("month")).thenReturn("month");
 
@@ -273,7 +270,7 @@ public class FilterQueryParserTest {
     }
 
     @Test
-    public void testActiveFacetObj_validfq() {
+    public void testActiveFacetObj_validfq() throws QidMissingException {
         // test valid fqs
         List<Facet> facetList = new ArrayList<>();
         facetList.add(new Facet("month", "Month:\"August\"", "month:\"08\""));
@@ -303,7 +300,7 @@ public class FilterQueryParserTest {
         runFqParsingTest(facetList);
     }
 
-    private void runFqParsingTest(List<Facet> facets) {
+    private void runFqParsingTest(List<Facet> facets) throws QidMissingException {
         SpatialSearchRequestParams query = new SpatialSearchRequestParams();
 
         // collect values into fq list
@@ -314,7 +311,7 @@ public class FilterQueryParserTest {
     }
 
     @Test
-    public void testActiveFacetObj_invalidfq() {
+    public void testActiveFacetObj_invalidfq() throws QidMissingException {
         SpatialSearchRequestParams query = new SpatialSearchRequestParams();
         // Construct fq
         query.setFq(new String[] {null, "", " ", "month", "   month  ", "(month", "month)", "(month:\"11\"", "month\"11\"", ":\"11\"", "    :\"11\"", "(:\"11\")", "(    :\"11\")", "month:", "month:   ",  "(month:   )", "-(month:   )"});

--- a/src/test/java/au/org/ala/biocache/dao/QueryFormatTest.java
+++ b/src/test/java/au/org/ala/biocache/dao/QueryFormatTest.java
@@ -163,7 +163,7 @@ public class QueryFormatTest {
      */
     @Test
     @Ignore
-    public void testQueryFormatting() {
+    public void testQueryFormatting() throws QidMissingException {
         for (SearchQueryTester sqt : data()) {
             SpatialSearchRequestParams ssrp = new SpatialSearchRequestParams();
             ssrp.setQ(sqt.query);
@@ -182,7 +182,7 @@ public class QueryFormatTest {
      * Run the tests with quality filters
      */
     @Test
-    public void testQueryFormattingWithQualityFilters() {
+    public void testQueryFormattingWithQualityFilters() throws QidMissingException {
         Map<String, String> filters = new LinkedHashMap();
         filters.put("first", "foo:bar");
         filters.put("second", "baz:qux");


### PR DESCRIPTION
Fixes for duplicate services to support the display of duplicate records on occurrence record pages.

Namely the service: `/ws/duplicates/<UUID>`

Also includes:
* Changes for taxonRankID for consistency with taxonRank
* Fix for heatmaps so that QID queries render
* Set content type on PNGs in WMS controller

