### PR TITLE
Pipeline 292 cassandra migration script

### DIFF
--- a/scripts/migrateUserAssertions/qa_format.py
+++ b/scripts/migrateUserAssertions/qa_format.py
@@ -1,32 +1,38 @@
-import csv
 import json
-
 
 def convert(csvFilePath, jsonFilePath):
     data = {}
 
     with open(csvFilePath, encoding='utf-8') as csvf:
-        csvReader = csv.DictReader(csvf, dialect='unix', delimiter='\t')
-        for rows in csvReader:
-            if len(rows) > 2:
-                key = rows['rowkey']
-                if key not in data:
-                    data[key] = []
-                for s in rows:
-                    rows[s] = rows[s].replace('\t', ' ')
-                data[key].append(rows);
+        delimiter = '\t'
+        linenum = 0
+        columns = {}
+        for row in csvf:
+            contents = row.rstrip('\n').split(delimiter)
+            # first line is header
+            if linenum == 0:
+                linenum = linenum + 1
+                for idx in range(0, len(contents)):
+                    columns[idx] = contents[idx]
+            else:
+                if len(contents) >= len(columns):
+                    oneline = {}
+                    for idx in range(0, len(contents)):
+                        # cqlsh COPY TO sometimes wrap values with ""
+                        if contents[idx].startswith('"') and contents[idx].endswith('"'):
+                            contents[idx] = contents[idx][1:-1]
+                        oneline[columns[idx]] = contents[idx]
 
-        with open(jsonFilePath, 'w', encoding='utf-8') as csvfile:
-            fieldnames = ['key', 'data']
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames, dialect='unix', delimiter='\t',
-                                    quoting=csv.QUOTE_NONE,
-                                    doublequote=False, escapechar=None, quotechar=None)
+                    key = oneline['rowkey']
+                    if key not in data:
+                        data[key] = []
+
+                    data[key].append(oneline)
+
+        with open(jsonFilePath, 'w', encoding='utf-8') as csvf:
             for k in data:
-                map = {}
-                map['key'] = k;
-                map['data'] = json.dumps(data[k], indent=False).replace('\n', '')
-                writer.writerow(map)
-
+                temp = json.dumps(data[k], indent=False).replace('\n', '')
+                csvf.write('\t'.join([k, temp]) + '\n')
 
 csvFilePath = r'/data/tmp/qa_dump.cql'
 jsonFilePath = r'/data/tmp/qa.csv'

--- a/src/main/java/au/org/ala/biocache/dao/CassandraStoreDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/CassandraStoreDAOImpl.java
@@ -18,8 +18,10 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
 import com.datastax.driver.extras.codecs.MappingCodec;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.TypeToken;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.log4j.Logger;
@@ -30,6 +32,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -147,7 +150,12 @@ public class CassandraStoreDAOImpl implements StoreDAO {
     public <T> void put(String key, T data) throws IOException {
         String className = data.getClass().getSimpleName();
 
-        String value = JSONObject.fromObject(data).toString();
+        String value;
+        if (data instanceof Collection) {
+            value = JSONArray.fromObject(data).toString();
+        } else {
+            value = JSONObject.fromObject(data).toString();
+        }
 
         try {
             BoundStatement boundStatement = createPutStatement(key, className, value);

--- a/src/main/java/au/org/ala/biocache/dto/AssertionCodes.java
+++ b/src/main/java/au/org/ala/biocache/dto/AssertionCodes.java
@@ -2,6 +2,7 @@ package au.org.ala.biocache.dto;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static au.org.ala.biocache.dto.ErrorCode.Category.Error;
@@ -173,6 +174,14 @@ public class AssertionCodes {
         }
         return list.toArray(new ErrorCode[0]);
 
+    }
+
+    public static ErrorCode getById(int code) {
+
+        return Arrays.stream(getAll())
+                .filter(errorCode -> errorCode.code == code)
+                .findFirst()
+                .orElse(null);
     }
 
     public static ErrorCode getByName(String name) {


### PR DESCRIPTION
The migration issue is caused by several factors:
- ` cqlsh COPY TO `command generates some values with surrounding `""`
    As a solution, I choose to manually remove them if a value starts and ends with "
- But another issue is csv.DictReader can't even read properly (see my screen capture in https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/291)

As a result, I just changed to manually read csv file line by line and use string split to get elements. Then remove any surrounding "".


