### PR TITLE
fixed issues in migration script for #291

### DIFF
--- a/scripts/migrateUserAssertions/qa_format.py
+++ b/scripts/migrateUserAssertions/qa_format.py
@@ -1,32 +1,38 @@
-import csv
 import json
-
 
 def convert(csvFilePath, jsonFilePath):
     data = {}
 
     with open(csvFilePath, encoding='utf-8') as csvf:
-        csvReader = csv.DictReader(csvf, dialect='unix', delimiter='\t')
-        for rows in csvReader:
-            if len(rows) > 2:
-                key = rows['rowkey']
-                if key not in data:
-                    data[key] = []
-                for s in rows:
-                    rows[s] = rows[s].replace('\t', ' ')
-                data[key].append(rows);
+        delimiter = '\t'
+        linenum = 0
+        columns = {}
+        for row in csvf:
+            contents = row.rstrip('\n').split(delimiter)
+            # first line is header
+            if linenum == 0:
+                linenum = linenum + 1
+                for idx in range(0, len(contents)):
+                    columns[idx] = contents[idx]
+            else:
+                if len(contents) >= len(columns):
+                    oneline = {}
+                    for idx in range(0, len(contents)):
+                        # cqlsh COPY TO sometimes wrap values with ""
+                        if contents[idx].startswith('"') and contents[idx].endswith('"'):
+                            contents[idx] = contents[idx][1:-1]
+                        oneline[columns[idx]] = contents[idx]
 
-        with open(jsonFilePath, 'w', encoding='utf-8') as csvfile:
-            fieldnames = ['key', 'data']
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames, dialect='unix', delimiter='\t',
-                                    quoting=csv.QUOTE_NONE,
-                                    doublequote=False, escapechar=None, quotechar=None)
+                    key = oneline['rowkey']
+                    if key not in data:
+                        data[key] = []
+
+                    data[key].append(oneline)
+
+        with open(jsonFilePath, 'w', encoding='utf-8') as csvf:
             for k in data:
-                map = {}
-                map['key'] = k;
-                map['data'] = json.dumps(data[k], indent=False).replace('\n', '')
-                writer.writerow(map)
-
+                temp = json.dumps(data[k], indent=False).replace('\n', '')
+                csvf.write('\t'.join([k, temp]) + '\n')
 
 csvFilePath = r'/data/tmp/qa_dump.cql'
 jsonFilePath = r'/data/tmp/qa.csv'


### PR DESCRIPTION
The migration issue is caused by several factors:

-  `cqlsh COPY TO` command generates some values with surrounding ""
    As a solution, I chose to manually remove them if a value starts and ends with "
- But another issue is `csv.DictReader` can't even read properly (see my screen capture in AtlasOfLivingAustralia/la-pipelines#291)
- The `csv.DictWriter `also has an issue I don't remember exactly. Look at the code
```
                map = {}
                map['key'] = k;
                map['data'] = json.dumps(data[k], indent=False).replace('\n', '')
                writer.writerow(map)
```
   `map['data']` is the returned value of `json.dumps()`, there's no way it's not a valid json. But the reality is, migrated data field could be invalid. So I changed to write csv file manually.

As a result, I just changed to manually read csv file line by line and use string split to get elements. Then remove any surrounding "". 