### PR TITLE
update solr after user assertion is added/removed/verified

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/IndexDAO.java
+++ b/src/main/java/au/org/ala/biocache/dao/IndexDAO.java
@@ -5,10 +5,12 @@ import au.org.ala.biocache.dto.SearchRequestParams;
 import au.org.ala.biocache.dto.SpatialSearchRequestParams;
 import au.org.ala.biocache.dto.StatsIndexFieldDTO;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.FieldStatsInfo;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.SolrParams;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,4 +50,6 @@ public interface IndexDAO {
     Map<String, FieldStatsInfo> getStatistics(SpatialSearchRequestParams searchParams) throws Exception;
 
     QueryResponse runSolrQuery(SolrQuery solrQuery, SearchRequestParams requestParams) throws Exception;
+
+    void indexFromMap(String guid, Map<String, Object> map) throws IOException, SolrServerException;
 }

--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -240,9 +240,28 @@ public class AssertionService {
 
         // put assertion status into index map
         indexMap.put("userAssertions", String.valueOf(assertionStatus));
-
         // set hasUserAssertions
         indexMap.put("hasUserAssertions", !assertions.isEmpty());
+
+        if (!userAssertions.isEmpty()) {
+            userAssertions.sort((qa1, qa2) -> {
+                try {
+                    Date date1 = simpleDateFormat.parse(qa1.getCreated());
+                    Date date2 = simpleDateFormat.parse(qa2.getCreated());
+                    return date2.compareTo(date1);
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    throw new IllegalArgumentException(e);
+                }
+            });
+            Date lastDate = null;
+            try {
+                lastDate = simpleDateFormat.parse(userAssertions.get(0).getCreated());
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+            indexMap.put("lastAssertionDate", lastDate);
+        }
 
         List<String> assertionUserIds = assertions.stream().map(QualityAssertion::getUserId).distinct().collect(Collectors.toList());
         if (!assertionUserIds.isEmpty()) {

--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -1,5 +1,6 @@
 package au.org.ala.biocache.service;
 
+import au.org.ala.biocache.dao.IndexDAO;
 import au.org.ala.biocache.dao.StoreDAO;
 import au.org.ala.biocache.dto.AssertionCodes;
 import au.org.ala.biocache.dto.AssertionStatus;
@@ -9,16 +10,16 @@ import au.org.ala.biocache.util.OccurrenceUtils;
 import org.apache.solr.common.SolrDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.stream.Collectors;
 
-@Component
+@Service
 public class AssertionService {
 
     private static final Logger logger = LoggerFactory.getLogger(AssertionService.class);
@@ -27,6 +28,10 @@ public class AssertionService {
     private OccurrenceUtils occurrenceUtils;
     @Inject
     private StoreDAO store;
+    @Inject
+    private IndexDAO indexDao;
+
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     public Optional<QualityAssertion> addAssertion(
             String recordUuid,
@@ -63,7 +68,7 @@ public class AssertionService {
             UserAssertions newAssertions = new UserAssertions();
             newAssertions.add(qa);
             UserAssertions combinedAssertions = getCombinedAssertions(existingAssertions, newAssertions);
-            store.put(recordUuid, combinedAssertions);
+            UpdateUserAssertions(recordUuid, combinedAssertions);
             return Optional.of(qa);
         }
 
@@ -79,11 +84,7 @@ public class AssertionService {
             // if there's any change made
             if (userAssertions.deleteUuid(assertionUuid)) {
                 // Update assertions
-                if (!userAssertions.isEmpty()) {
-                    store.put(recordUuid, userAssertions);
-                } else { // no assertions, delete the entry
-                    store.delete(UserAssertions.class, recordUuid);
-                }
+                UpdateUserAssertions(recordUuid, userAssertions);
                 return true;
             }
         }
@@ -118,7 +119,7 @@ public class AssertionService {
             UserAssertions existingAssertions = store.get(UserAssertions.class, recordUuid).orElse(new UserAssertions());
             UserAssertions combinedAssertions = getCombinedAssertions(existingAssertions, userAssertions);
             if (!combinedAssertions.isEmpty()) {
-                store.put(recordUuid, combinedAssertions);
+                UpdateUserAssertions(recordUuid, combinedAssertions);
             }
             return true;
         }
@@ -179,5 +180,85 @@ public class AssertionService {
         combined.addAll(existingVerificationMap.values());
 
         return combined;
+    }
+
+    // * There are 5 states for User Assertion Status:
+    // * NONE: If no user assertion record exist
+    // * UNCONFIRMED: If there is a user assertion but has not been verified by Collection Admin
+    // * OPEN ISSUE: Collection Admin verifies the record and flags the user assertion as Open issue
+    // * VERIFIED: Collection Admin verifies the record and flags the user assertion as Verified
+    // * CORRECTED: Collection Admin verifies the record and flags the user assertion as Corrected
+    private void UpdateUserAssertions(String recordUuid, UserAssertions userAssertions) throws IOException {
+        // update database
+        if (!userAssertions.isEmpty()) {
+            store.put(recordUuid, userAssertions);
+        } else { // no assertions, delete the entry
+            store.delete(UserAssertions.class, recordUuid);
+        }
+
+        Map<String, Object> indexMap = new HashMap<>();
+
+        // set default user assertion status QA_NONE, means there's no assertion
+        Integer assertionStatus = AssertionStatus.QA_NONE;
+
+        // original user assertions
+        List<QualityAssertion> assertions =
+                userAssertions.stream().filter(qa -> !qa.getCode().equals(AssertionCodes.VERIFIED.getCode())).collect(Collectors.toList());
+
+        // admin verifications
+        List<QualityAssertion> verifications =
+                userAssertions.stream().filter(qa -> qa.getCode().equals(AssertionCodes.VERIFIED.getCode())).collect(Collectors.toList());
+
+        List<String> assertionIds = assertions.stream().map(QualityAssertion::getUuid).collect(Collectors.toList());
+        List<String> verifiedIds = verifications.stream().map(QualityAssertion::getRelatedUuid).collect(Collectors.toList());
+
+        // only those not yet verified left
+        assertionIds.removeAll(verifiedIds);
+
+        // if there's user assertion not yet verified
+        if (!assertionIds.isEmpty()) {
+            assertionStatus = AssertionStatus.QA_UNCONFIRMED;
+        } else if (!verifications.isEmpty()) { // all verified
+            if (verifications.stream().anyMatch(qa -> qa.getQaStatus().equals(AssertionStatus.QA_OPEN_ISSUE))) {
+                assertionStatus = AssertionStatus.QA_OPEN_ISSUE;
+            } else {
+                // sort by datetime DESC
+                verifications.sort((qa1, qa2) -> {
+                    try {
+                        return simpleDateFormat.parse(qa2.getCreated()).compareTo(simpleDateFormat.parse(qa1.getCreated()));
+                    } catch (ParseException e) {
+                        e.printStackTrace();
+                        throw new IllegalArgumentException(e);
+                    }
+                });
+
+                assertionStatus = verifications.get(0).getQaStatus();
+            }
+        }
+
+        // put assertion status into index map
+        indexMap.put("userAssertionStatus", String.valueOf(assertionStatus));
+
+        if (!userAssertions.isEmpty()) {
+            userAssertions.sort((qa1, qa2) -> {
+                try {
+                    return simpleDateFormat.parse(qa2.getCreated()).compareTo(simpleDateFormat.parse(qa1.getCreated()));
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                    throw new IllegalArgumentException(e);
+                }
+            });
+        }
+
+        List<String> assertionUserIds = assertions.stream().map(QualityAssertion::getUserId).distinct().collect(Collectors.toList());
+        if (!assertionUserIds.isEmpty()) {
+            indexMap.put("assertion_user_id", assertionUserIds);
+        }
+
+        try {
+            indexDao.indexFromMap(recordUuid, indexMap);
+        } catch (Exception e) {
+            logger.error("Failed to update Solr index, e = " + e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
- This commit includes changes to update solr document after user assertion is addede/removed/verified.
- These 2 fields will be added to solr document:
> 1. `user_assertions` this is the assertion status of this record (string type)
>2. `assertion_user_id` this is the list of user ids who have made an annotation on this record (list<string> type)
- with these 2 fields added, user will be able to query solr with `fq=assertion_user_id:56528` and `fq=user_assertions:50001`

see below example
<img width="924" alt="截屏2021-05-11 下午3 52 37" src="https://user-images.githubusercontent.com/61677987/117765203-f3206580-b270-11eb-86a4-8a6bf4896d54.png">


___
Changes were made per code review. Now the updated solr doc looks like this:
<img width="941" alt="截屏2021-05-12 上午9 37 55" src="https://user-images.githubusercontent.com/61677987/117909151-0e48af00-b31d-11eb-8de6-160ed282ff62.png">

