### PR TITLE
an API to trigger index of all user assertions

### DIFF
--- a/solr/conf/managed-schema
+++ b/solr/conf/managed-schema
@@ -137,6 +137,8 @@
 
   <field name="id" type="string" docValues="true" multiValued="false" indexed="true"/>
 
+  <!-- required for solr optimistic concurrency udpate -->
+  <field name="_version_" type="long" docValues="true" indexed="false" stored="false"/>
   <!-- required for WMS -->
   <field name="point-0.0001"  type="string" docValues="true" indexed="true" />
   <field name="point-0.001"   type="string" docValues="true" indexed="true" />

--- a/src/main/java/au/org/ala/biocache/dao/CassandraStoreDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/CassandraStoreDAOImpl.java
@@ -34,11 +34,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Cassandra 3 based implementation of a persistence manager.
@@ -151,6 +147,24 @@ public class CassandraStoreDAOImpl implements StoreDAO {
         }
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public <T> List<T> getAll(Class<T> dataClass) throws IOException {
+        List<T> result = new ArrayList<>();
+        ResultSet rs = session.execute("SELECT * FROM " + dataClass.getSimpleName());
+
+        for (Row row : rs) {
+            String jsonString = row.get(1, String.class);
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+
+            result.add(mapper.readValue(jsonString, dataClass));
+        }
+
+        return result;
     }
 
     @Override

--- a/src/main/java/au/org/ala/biocache/dao/IndexDAO.java
+++ b/src/main/java/au/org/ala/biocache/dao/IndexDAO.java
@@ -11,6 +11,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.SolrParams;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,5 +52,5 @@ public interface IndexDAO {
 
     QueryResponse runSolrQuery(SolrQuery solrQuery, SearchRequestParams requestParams) throws Exception;
 
-    void indexFromMap(String guid, Map<String, Object> map) throws IOException, SolrServerException;
+    void indexFromMap(List<Map<String, Object>> maps) throws IOException, SolrServerException;
 }

--- a/src/main/java/au/org/ala/biocache/dao/StoreDAO.java
+++ b/src/main/java/au/org/ala/biocache/dao/StoreDAO.java
@@ -1,6 +1,7 @@
 package au.org.ala.biocache.dao;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -8,6 +9,8 @@ import java.util.Optional;
  */
 public interface StoreDAO {
     <T> Optional<T> get(Class<T> dataClass, String key) throws IOException;
+
+    <T> List<T> getAll(Class<T> dataClass) throws IOException;
 
     <T> void put(String key, T data) throws IOException;
 

--- a/src/main/java/au/org/ala/biocache/web/AssertionController.java
+++ b/src/main/java/au/org/ala/biocache/web/AssertionController.java
@@ -324,6 +324,21 @@ public class AssertionController extends AbstractSecureController {
         return new ArrayList<>();
     }
 
+    @RequestMapping(value = {"/sync"}, method = RequestMethod.GET)
+    public @ResponseBody Boolean showSensitiveOccurrence(@RequestParam(value="apiKey", required=true) String apiKey,
+                                                        HttpServletResponse response) throws Exception {
+        if (isValidKey(apiKey)) {
+            if (assertionService.indexAll()) {
+                response.setStatus(HttpServletResponse.SC_OK);
+            } else {
+                response.setStatus(HttpServletResponse.SC_OK, "An index all user assertions job already running. Your request won't be processed.");
+            }
+        } else {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "An invalid API Key was provided.");
+        }
+        return null;
+    }
+
     public void setAssertionUtils(AssertionUtils assertionUtils) {
         this.assertionUtils = assertionUtils;
     }

--- a/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
+++ b/src/test/java/au/org/ala/biocache/service/AssertionServiceTest.java
@@ -87,7 +87,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "0",
@@ -100,11 +100,13 @@ public class AssertionServiceTest {
         assert(myUserAssertions.getValue().get(0).getComment().equals("comment"));
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50005"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        assert(((List<String>)myIndexMap.getValue().get("assertionUserId")).size() == 1);
-        assert(((List<String>)myIndexMap.getValue().get("assertionUserId")).get(0).equals("userId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        assert(myIndexMaps.getValue().size() == 1);
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50005"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        assert(((List<String>)indexMap.get("assertionUserId")).size() == 1);
+        assert(((List<String>)indexMap.get("assertionUserId")).get(0).equals("userId"));
     }
 
     @Test
@@ -116,7 +118,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "1",
@@ -132,10 +134,11 @@ public class AssertionServiceTest {
         assert(codes.contains(1));
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50005"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        Set<String> userIds = new HashSet<>((List<String>)myIndexMap.getValue().get("assertionUserId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50005"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        Set<String> userIds = new HashSet<>((List<String>)indexMap.get("assertionUserId"));
         assert(userIds.size() == 2);
         assert(userIds.contains("userId"));
         assert(userIds.contains("userId1"));
@@ -150,7 +153,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "0",
@@ -164,10 +167,11 @@ public class AssertionServiceTest {
         assert(myUserAssertions.getValue().get(0).getComment().equals("comment_new"));
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50005"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        Set<String> userIds = new HashSet<>((List<String>)myIndexMap.getValue().get("assertionUserId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50005"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        Set<String> userIds = new HashSet<>((List<String>)indexMap.get("assertionUserId"));
         assert(userIds.size() == 1);
         assert(userIds.contains("userId"));
     }
@@ -189,7 +193,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "50000",
@@ -206,10 +210,11 @@ public class AssertionServiceTest {
         assert(assertions.get(1).getCode() == 50000);
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50001"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        Set<String> userIds = new HashSet<>((List<String>)myIndexMap.getValue().get("assertionUserId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50001"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        Set<String> userIds = new HashSet<>((List<String>)indexMap.get("assertionUserId"));
         assert(userIds.size() == 1);
         assert(userIds.contains("userId"));
     }
@@ -231,7 +236,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "50000",
@@ -249,10 +254,11 @@ public class AssertionServiceTest {
         assert(assertions.get(1).getQaStatus() == 50002);
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50002"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        Set<String> userIds = new HashSet<>((List<String>)myIndexMap.getValue().get("assertionUserId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50002"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        Set<String> userIds = new HashSet<>((List<String>)indexMap.get("assertionUserId"));
         assert(userIds.size() == 1);
         assert(userIds.contains("userId"));
     }
@@ -267,7 +273,7 @@ public class AssertionServiceTest {
 
         ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<UserAssertions> myUserAssertions = ArgumentCaptor.forClass(UserAssertions.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // test when add succeed -- code = 50000
         Optional<QualityAssertion> qualityAssertion1 = assertionService.addAssertion("recordUuid", "50000",
@@ -285,10 +291,11 @@ public class AssertionServiceTest {
         assert(assertions.get(1).getQaStatus() == 50002);
 
         // verify indexmap
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        assert(myIndexMap.getValue().get("userAssertions").equals("50002"));
-        assert((boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        Set<String> userIds = new HashSet<>((List<String>)myIndexMap.getValue().get("assertionUserId"));
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
+        assert(indexMap.get("userAssertions").equals("50002"));
+        assert((boolean)indexMap.get("hasUserAssertions"));
+        Set<String> userIds = new HashSet<>((List<String>)indexMap.get("assertionUserId"));
         assert(userIds.size() == 1);
         assert(userIds.contains("userId"));
     }
@@ -309,7 +316,7 @@ public class AssertionServiceTest {
         when(store.get(Mockito.any(), Mockito.any())).thenReturn(Optional.of(getMockAssertions(0, 0)));
         assert(!assertionService.deleteAssertion("recordUuid", "assertionUuid"));
         Mockito.verify(store, never()).delete(Mockito.any(), Mockito.any());
-        Mockito.verify(indexDAO, never()).indexFromMap(Mockito.any(), Mockito.any());
+        Mockito.verify(indexDAO, never()).indexFromMap(Mockito.any());
 
     }
 
@@ -321,7 +328,7 @@ public class AssertionServiceTest {
 
         assert(!assertionService.deleteAssertion("recordUuid", "invalid_assertionUuid"));
         Mockito.verify(store, never()).put(Mockito.any(), Mockito.any());
-        Mockito.verify(indexDAO, never()).indexFromMap(Mockito.any(), Mockito.any());
+        Mockito.verify(indexDAO, never()).indexFromMap(Mockito.any());
     }
 
     @Test
@@ -336,16 +343,15 @@ public class AssertionServiceTest {
         // verify delete cassandra called
         Mockito.verify(store).delete(Mockito.any(), Mockito.any());
 
-        ArgumentCaptor<String> myUuid = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Map<String, Object>> myIndexMap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<List<Map<String, Object>>> myIndexMaps = ArgumentCaptor.forClass(List.class);
 
         // verify index
-        Mockito.verify(indexDAO).indexFromMap(myUuid.capture(), myIndexMap.capture());
-        Map<String, Object> value = myIndexMap.getValue();
+        Mockito.verify(indexDAO).indexFromMap(myIndexMaps.capture());
+        Map<String, Object> indexMap = myIndexMaps.getValue().get(0);
 
-        assert(myIndexMap.getValue().get("userAssertions").equals(String.valueOf(AssertionStatus.QA_NONE)));
-        assert(!(boolean)myIndexMap.getValue().get("hasUserAssertions"));
-        assert(!myIndexMap.getValue().containsKey("assertionUserId"));
+        assert(indexMap.get("userAssertions").equals(String.valueOf(AssertionStatus.QA_NONE)));
+        assert(!(boolean)indexMap.get("hasUserAssertions"));
+        assert(!indexMap.containsKey("assertionUserId"));
     }
 
     @Test
@@ -363,7 +369,7 @@ public class AssertionServiceTest {
         assert(assertionService.getAssertions("recordUuid").get(0).getUuid().equals(qualityAssertions.get(0).getUuid()));
         assert(assertionService.getAssertions("recordUuid").get(1).getUuid().equals(qualityAssertions.get(1).getUuid()));
     }
-    
+
     @Test
     public void testGetOneAssertion() throws Exception {
         // store.get(UserAssertions.class, recordUuid).orElse(new UserAssertions());


### PR DESCRIPTION
This PR provides an API to trigger indexing of all user assertions.

One possible scenario we need to handle is the record the assertion associated with no longer exists in solr.

For example, if we have assertions for records [id1, id2, id3, id4, id5] and suppose record with id3 no longer exists in solr.

By default, solr will create a new record with id3 and those user assertions fields which is not what we want.

So we specify _version_ = 1, meaning only update when the id exists. With this setting, solr throws an exception for id3, saying 'no match record found' which is what we expect. But the thing is, all other subsequent update calls fail. I've tried different ways, but none works. It should be a bug for solr. So 1 failed update causes all subsequent update to fail even when their ids are correct.

So we need to make sure any record being updated actually exists in solr. For every assertion in the database, before updating corresponding doc, we call solr API to check if the record exists in solr. Only when it exists, we'll do update for it.


