### PR TITLE
assertionUserId also includes those user who made verification

### DIFF
--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -7,6 +7,7 @@ import au.org.ala.biocache.dto.*;
 import au.org.ala.biocache.util.OccurrenceUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.apache.commons.lang.StringUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.jetbrains.annotations.NotNull;
@@ -326,7 +327,7 @@ public class AssertionService {
             indexMap.put("lastAssertionDate", lastDate);
         }
 
-        List<String> assertionUserIds = assertions.stream().map(QualityAssertion::getUserId).distinct().collect(Collectors.toList());
+        List<String> assertionUserIds = userAssertions.stream().map(QualityAssertion::getUserId).filter(StringUtils::isNotBlank).distinct().collect(Collectors.toList());
         if (!assertionUserIds.isEmpty()) {
             indexMap.put("assertionUserId", assertionUserIds);
         }


### PR DESCRIPTION
As a reference, these 2 records are returned by the `fq=assertion_user_id:"10012"` search from prod

https://biocache.ala.org.au/occurrences/63c21147-d3b9-4454-9681-bbed1790d250
https://biocache.ala.org.au/occurrences/c6aaa0c9-6b06-4ef5-b0fa-dd3a402d5116

but user 10012 (Nimal Karunajeewa) only verified the user assertions.

Old code only checks the uids who created normal (non-verification) user assertions. The change is to get uids from all user assertions.

