### PR TITLE
filter out empty fq which causes crash

### DIFF
--- a/scripts/migrateQids/qid_format.groovy
+++ b/scripts/migrateQids/qid_format.groovy
@@ -66,6 +66,12 @@
         qid.source = line[7] ? line[7] : null
         qid.wkt = line[8] ? line[8] : null
 
+        // fqs can contain empty fq which causes generator.toJson() crash
+        // for example in prod, qid 1495081066189 has fqs = ["","longitude:[-180 TO 180]","latitude:[-90 TO 90]"]
+        if (qid.fqs) {
+            qid.fqs = qid.fqs.findAll{it.length() > 0} ?: null
+        }
+
         if (qid.fqs){
             if (qid.fqs){
                 qid.fqs = qid.fqs.collect { it.replace('"', '\\"') }

--- a/scripts/migrateQids/qid_format.groovy
+++ b/scripts/migrateQids/qid_format.groovy
@@ -1,6 +1,6 @@
     @Grab('com.opencsv:opencsv:5.4')
     @Grab(group='commons-collections', module='commons-collections', version='3.2.1')
-
+    @Grab(group='org.codehaus.groovy', module='groovy-json', version='3.0.0')
     import com.opencsv.CSVReader
     import com.opencsv.CSVWriter
     import groovy.json.JsonSlurper;


### PR DESCRIPTION
There are **118973** entries in prod `qid` database that have an empty `fq`

for example:

qid.rowkey = 1438652996011, line3 fqs = [, -(data_provider:* AND -data_provider:"Australian Seedbank Partnership" AND -data_provider:"Global Biodiversity Information Facility" AND -data_provider:"DigiVol" AND -data_provider:"Barcode of Life" AND -data_provider:"South Australia, Department of Environment, Water and Natural Resources" AND -data_provider:"Australia's Virtual Herbarium" AND -data_provider:"Citizen Science - ALA Website" AND -data_provider:"Australian National Insect Collection, CSIRO Entomology" AND -data_provider:"University of Adelaide" AND -data_provider:"BirdLife Australia" AND -data_provider:"Office of Environment and Heritage, Department of Premier and Cabinet representing the State of New South Wales" AND -data_provider:"OZCAM (Online Zoological Collections of Australian Museums) Provider" AND -data_provider:"European Molecular Biology Laboratory Australia"), longitude:[* TO *], latitude:[* TO *], -(data_provider:* AND -data_provider:"Australian Seedbank Partnership" AND -data_provider:"Global Biodiversity Information Facility" AND -data_provider:"DigiVol" AND -data_provider:"Barcode of Life" AND -data_provider:"South Australia, Department of Environment, Water and Natural Resources" AND -data_provider:"Australia's Virtual Herbarium" AND -data_provider:"Citizen Science - ALA Website" AND -data_provider:"Australian National Insect Collection, CSIRO Entomology" AND -data_provider:"University of Adelaide" AND -data_provider:"BirdLife Australia" AND -data_provider:"Office of Environment and Heritage, Department of Premier and Cabinet representing the State of New South Wales" AND -data_provider:"OZCAM (Online Zoological Collections of Australian Museums) Provider" AND -data_provider:"European Molecular Biology Laboratory Australia")]
qid.rowkey = 1490324552661, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1437620655683, line3 fqs = [, longitude:[* TO *], latitude:[* TO *]]
qid.rowkey = 1437442613555, line3 fqs = [, longitude:[* TO *], latitude:[* TO *]]
qid.rowkey = 1461559649623, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1457832874605, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1481074739992, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1466564235847, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1439464675131, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1495943267345, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1465107343018, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1485234351867, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1453180089336, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1444621020701, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1488751419928, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1443155850684, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1463288512001, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1455868196491, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]
qid.rowkey = 1453622416695, line3 fqs = [, longitude:[-180 TO 180], latitude:[-90 TO 90]]

