### PR TITLE
Custom CloudSolrStream

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -1721,13 +1721,13 @@ public class SearchDAOImpl implements SearchDAO {
                     }
                 } else {
 
-                    solrQuery.addFacetField(facet); // PIPELINES: SolrQuery::addFacetField entry point
+                    solrQuery.addFacetField(facet);
 
                     if ("".equals(searchParams.getFsort()) && substituteDefaultFacetOrder && FacetThemes.getFacetsMap().containsKey(facet)) {
                         //now check if the sort order is different to supplied
-                        String thisSort = FacetThemes.getFacetsMap().get(facet).getSort();
+                        String thisSort = FacetThemes.getFacetsMap().get(facet).getSort();  // thisSort = index or count
                         if (!searchParams.getFsort().equalsIgnoreCase(thisSort))
-                            solrQuery.add("f." + facet + ".facet.sort", thisSort);
+                            solrQuery.add("f." + fieldMappingUtil.translateFieldName(facet) + ".facet.sort", thisSort);
                     }
 
                 }
@@ -2330,14 +2330,16 @@ public class SearchDAOImpl implements SearchDAO {
                 if (facets > 0) sb.append(",");
                 facets++;
 
-                sb.append(facet).append(":{type:terms,limit:-1,sort:index,field:").append(facet).append(",facet:{");
+                sb.append(facet).append(":{type:terms,limit:-1,sort:index,field:").
+                        append(fieldMappingUtil.translateFieldName(facet)).append(",facet:{");
 
                 int fls = 0;
                 for (String fl : searchParams.getFl().split(",")) {
                     if (fls > 0) sb.append(",");
                     fls++;
 
-                    sb.append(fl).append(":{type:terms,limit:1,sort:index,field:").append(fl).append("}");
+                    sb.append(fieldMappingUtil.translateFieldName(fl)).append(":{type:terms,limit:1,sort:index,field:").
+                            append(fieldMappingUtil.translateFieldName(fl)).append("}");
                 }
                 sb.append("}}}");
             }
@@ -2542,7 +2544,7 @@ public class SearchDAOImpl implements SearchDAO {
         //stats parameters
         query.add("stats", "true");
         if (facet != null) query.add("stats.facet", facet);
-        query.add("stats.field", "{!" + StringUtils.join(statType, "=true ") + "=true}" + field);
+        query.add("stats.field", "{!" + StringUtils.join(statType, "=true ") + "=true}" + fieldMappingUtil.translateFieldName(field));
 
         QueryResponse response = indexDao.runSolrQuery(query);
 

--- a/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
+++ b/src/main/java/au/org/ala/biocache/dto/OccurrenceIndex.java
@@ -160,7 +160,7 @@ public class OccurrenceIndex {
     Integer month;
     @Field("basisOfRecord")
     String basisOfRecord;
-    @Field("typeStaus")
+    @Field("typeStatus")
     String typeStatus;
     @Field("locationRemarks")
     String raw_locationRemarks;

--- a/src/main/java/au/org/ala/biocache/util/solr/FieldMappedSolrParams.java
+++ b/src/main/java/au/org/ala/biocache/util/solr/FieldMappedSolrParams.java
@@ -44,7 +44,7 @@ public class FieldMappedSolrParams extends SolrParams {
 
             Consumer<Pair<String, String>> addParamTranslation = (Pair<String, String> mapping) -> {
 
-                String[] old = inverseTranslations.put(mapping.getRight(), new String[]{ mapping.getLeft() });
+                String[] old = inverseTranslations.put(mapping.getRight(), new String[]{mapping.getLeft()});
 
                 if (old != null) {
 
@@ -90,7 +90,7 @@ public class FieldMappedSolrParams extends SolrParams {
                                                 String translatedField = fieldMappingUtil.translateFieldName(sortParams[0]);
                                                 return translatedField + " " + sortParams[1];
                                             })
-                                            .collect(Collectors.joining( "," ))
+                                            .collect(Collectors.joining(","))
                             )
                             .toArray(String[]::new);
 
@@ -99,6 +99,8 @@ public class FieldMappedSolrParams extends SolrParams {
 
                 case "facet.field":
                 case "facet.range":
+                case "facet.pivot":
+                case "stats.facet":
 
                     translatedSolrParams.set(paramName, fieldMappingUtil.translateFieldArray(addParamTranslation, solrParams.getParams(paramName)));
                     break;

--- a/src/main/java/org/apache/solr/client/solrj/io/stream/AlaCloudSolrStream.java
+++ b/src/main/java/org/apache/solr/client/solrj/io/stream/AlaCloudSolrStream.java
@@ -1,0 +1,51 @@
+package org.apache.solr.client.solrj.io.stream;
+
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Functionality of CloudSolrStream
+ * - remove assert of q, fl and sort
+ * - support 'distrib=true' to execute the request on a single SOLR instance
+ */
+public class AlaCloudSolrStream extends CloudSolrStream {
+
+    public AlaCloudSolrStream(String zkHost, String collectionName, SolrParams params) throws IOException {
+        this.init(zkHost, collectionName, params);
+    }
+
+    void init(String zkHost, String collectionName, SolrParams params) throws IOException {
+        this.zkHost = zkHost;
+        this.collection = collectionName;
+        this.params = new ModifiableSolrParams(params);
+
+        // super.init constructs this.comp when there is one request per shard, e.g. /export and /select requests
+        if (this.params.get("distrib", "false").equals("false")) {
+            super.init(collectionName, zkHost, params);
+        }
+    }
+
+    @Override
+    protected void constructStreams() throws IOException {
+
+        if (this.params.get("distrib", "false").equals("false")) {
+            // default request, one per shard
+            super.constructStreams();
+        } else {
+            // one request to the collection
+            constructStream();
+        }
+    }
+
+    void constructStream() throws IOException {
+        List<String> shardUrls = getShards(this.zkHost, this.collection, this.streamContext, new ModifiableSolrParams());
+
+        // only add the request to the first shard
+        SolrStream solrStream = new SolrStream(shardUrls.get(0), this.params);
+        solrStream.setStreamContext(this.streamContext);
+        this.solrStreams.add(solrStream);
+    }
+}


### PR DESCRIPTION
Added an extended CloudSolrStream that allows for a single request to the SOLR cluster instead of numberOfShards*requests and returning numberOfShards duplicates.