### PR TITLE
Epic/pipelines/453 qa=includeall not working

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -973,7 +973,7 @@ public class SearchDAOImpl implements SearchDAO {
 
             // Map assertions to the output columns with the assertion name in the header.
             // These assertion columns will contain the passed/failed values.
-            if ("includeAll".equals(downloadParams.getQa())) {
+            if ("includeall".equals(downloadParams.getQa())) {
                 downloadHeaders.qaIds = getAllQAFields().toString().split(",");
             } else if ("all".equals(downloadParams.getQa())) {
                 try {

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -923,7 +923,7 @@ public class SearchDAOImpl implements SearchDAO {
     /**
      * Process downloadRequestParams.fields and update for sensitive requests.
      *
-     * @param downloadRequestParams
+     * @param downloadParams
      * @param includeSensitive
      */
     private void prepareRequestedFields(DownloadRequestParams downloadParams, boolean includeSensitive) {
@@ -985,7 +985,13 @@ public class SearchDAOImpl implements SearchDAO {
                 } catch (Exception e) {
                     logger.error("error getting assertions facet for download: " + downloadParams, e);
                 }
+            } else {
+                // translate qa names into new assertion names
+                downloadHeaders.qaIds = Arrays.stream(downloadParams.getQa().split(","))
+                        .map((qa) -> fieldMappingUtil.translateFieldValue("assertions", qa))
+                        .toArray(String[]::new);
             }
+
             downloadHeaders.qaLabels = Arrays.stream(downloadHeaders.qaIds).map(id -> {
                 return messageSource.getMessage("assertions." + id, null, id, null);
             }).collect(Collectors.toList()).toArray(new String[0]);


### PR DESCRIPTION
AtlasOfLivingAustralia/la-pipelines#453 
 - changed `qa` param value to check `includeall` (not camel case value)
 - use `qa` param as the assertion name if not [ `all` | `incudeall` | `none` ]