### PR TITLE
a customized exception resolver to properly set model data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,12 @@
             <artifactId>jsr305</artifactId>
             <version>${findbugs-jsr305.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>4.3.24.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <build>

--- a/src/main/java/au/org/ala/biocache/web/CustomExceptionResolver.java
+++ b/src/main/java/au/org/ala/biocache/web/CustomExceptionResolver.java
@@ -1,0 +1,42 @@
+/**************************************************************************
+ *  Copyright (C) 2013 Atlas of Living Australia
+ *  All Rights Reserved.
+ *
+ *  The contents of this file are subject to the Mozilla Public
+ *  License Version 1.1 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of
+ *  the License at http://www.mozilla.org/MPL/
+ *
+ *  Software distributed under the License is distributed on an "AS
+ *  IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ *  implied. See the License for the specific language governing
+ *  rights and limitations under the License.
+ ***************************************************************************/
+package au.org.ala.biocache.web;
+
+import org.apache.solr.common.SolrException;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
+
+public class CustomExceptionResolver extends SimpleMappingExceptionResolver {
+    @Override
+    protected ModelAndView getModelAndView(String viewName, Exception ex) {
+        ModelAndView mv = new ModelAndView(viewName);
+
+        if (ex instanceof org.springframework.dao.DataAccessException ||
+            ex instanceof org.springframework.transaction.TransactionException) {
+            mv.addObject("error", ex);
+        } else {
+            // if user specified 'accept: application/json' in header, ContentNegotiatingViewResolver
+            // will try to convert the modal into json which could crash (exception can't  be mapped to a json value)
+            // so we construct a proper modal here
+            //
+            // if no 'application/json' specified, view resolver will resolve to jsp pages in which
+            // request.getAttribute("javax.servlet.error.exception") is used to get the exception and show details to user
+            // this function won't be affected by this custom class so jsp pages will work as before
+            mv.addObject("message", ex.getMessage());
+            mv.addObject("errorType", (ex instanceof SolrException) ? "Query syntax invalid" : "Server error");
+        }
+        return mv;
+    }
+}

--- a/src/main/java/au/org/ala/biocache/web/CustomExceptionResolver.java
+++ b/src/main/java/au/org/ala/biocache/web/CustomExceptionResolver.java
@@ -1,5 +1,5 @@
 /**************************************************************************
- *  Copyright (C) 2013 Atlas of Living Australia
+ *  Copyright (C) 2021 Atlas of Living Australia
  *  All Rights Reserved.
  *
  *  The contents of this file are subject to the Mozilla Public
@@ -18,25 +18,78 @@ import org.apache.solr.common.SolrException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Biocache-service Customised exception resolver.
+ *
+ * This exception resolver is customised to guarantee that the model can be successfully serialized to
+ * a JSON.
+ * @author "xuanyu huang <hua091@csiro.au>"
+ */
 public class CustomExceptionResolver extends SimpleMappingExceptionResolver {
+    /**
+     * Customised exception resolver by using our own version of determineStatusCode.
+     */
+    @Override
+    protected ModelAndView doResolveException(
+            HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+
+        // Expose ModelAndView for chosen error view.
+        String viewName = determineViewName(ex, request);
+        if (viewName != null) {
+            // Apply HTTP status code for error views, if specified.
+            // Only apply it if we're processing a top-level request.
+            Integer statusCode = determineStatusCode(request, viewName, ex);
+            if (statusCode != null) {
+                applyStatusCodeIfPossible(request, response, statusCode);
+            }
+            return getModelAndView(viewName, ex, request);
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Determine the HTTP status code to apply for the given error view.
+     * <p> If the exception is a solr exception, it uses the exception code as HTTP status
+     * code. Otherwise it uses default implementation to get the HTTP status code.
+     * @param request current HTTP request
+     * @param viewName the name of the error view
+     * @param ex the exception that got thrown during handler execution
+     * @return the HTTP status code to use
+     */
+    protected Integer determineStatusCode(HttpServletRequest request, String viewName, Exception ex) {
+        if (ex instanceof SolrException) {
+            return ((SolrException) ex).code();
+        } else {
+            return determineStatusCode(request, viewName);
+        }
+    }
+
+    /**
+     * Return a ModelAndView for the given view name and exception.
+     * <p>It overwrites the default implementation by setting a 'message' and 'errorType'
+     * fields into mv.
+     * @param viewName the name of the error view
+     * @param ex the exception that got thrown during handler execution
+     * @return the ModelAndView instance
+     */
     @Override
     protected ModelAndView getModelAndView(String viewName, Exception ex) {
         ModelAndView mv = new ModelAndView(viewName);
 
-        if (ex instanceof org.springframework.dao.DataAccessException ||
-            ex instanceof org.springframework.transaction.TransactionException) {
-            mv.addObject("error", ex);
-        } else {
-            // if user specified 'accept: application/json' in header, ContentNegotiatingViewResolver
-            // will try to convert the modal into json which could crash (exception can't  be mapped to a json value)
-            // so we construct a proper modal here
-            //
-            // if no 'application/json' specified, view resolver will resolve to jsp pages in which
-            // request.getAttribute("javax.servlet.error.exception") is used to get the exception and show details to user
-            // this function won't be affected by this custom class so jsp pages will work as before
-            mv.addObject("message", ex.getMessage());
-            mv.addObject("errorType", (ex instanceof SolrException) ? "Query syntax invalid" : "Server error");
-        }
+        // if user specified 'accept: application/json' in header, ContentNegotiatingViewResolver
+        // will try to convert the model into json which could crash (exception can't  be mapped to a json value)
+        // so we construct a proper model here
+        //
+        // if no 'application/json' specified, view resolver will resolve to jsp pages in which
+        // request.getAttribute("javax.servlet.error.exception") is used to get the exception and show details to user
+        // this function won't be affected by this custom class so jsp pages will work as before
+        mv.addObject("message", ex.getMessage());
+        mv.addObject("errorType", (ex instanceof SolrException) ? "Solr error" : "Server error");
         return mv;
     }
 }

--- a/src/main/webapp/WEB-INF/mainDispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/mainDispatcher-servlet.xml
@@ -66,8 +66,7 @@
       - is to propagate all exceptions to the servlet container: this will happen
       - here with all other types of exceptions.
      -->
-    <bean class="org.springframework.web.servlet.handler.SimpleMappingExceptionResolver">
-        <property name="exceptionAttribute" value="error"/>
+    <bean class="au.org.ala.biocache.web.CustomExceptionResolver">
         <property name="defaultStatusCode" value="500"/>
         <property name="exceptionMappings">
             <props>

--- a/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerIT.java
+++ b/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerIT.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:springTest.xml"})
 @WebAppConfiguration
-public class WMSOSGridControllerTest {
+public class WMSOSGridControllerIT {
     static {
         System.setProperty("biocache.config", System.getProperty("user.dir") + "/src/test/resources/biocache-test-config.properties");
     }

--- a/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerTest.java
@@ -1,7 +1,9 @@
 package au.org.ala.biocache.controller;
 
+import au.org.ala.biocache.util.SolrUtils;
 import au.org.ala.biocache.web.WMSOSGridController;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +36,11 @@ public class WMSOSGridControllerTest {
     @Autowired
     WebApplicationContext wac;
     MockMvc mockMvc;
+
+    @BeforeClass
+    public static void setupBeforeClass() throws Exception {
+        SolrUtils.setupIndex();
+    }
 
     @Before
     public void setup() {

--- a/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerTest.java
+++ b/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerTest.java
@@ -1,0 +1,75 @@
+package au.org.ala.biocache.controller;
+
+import au.org.ala.biocache.web.WMSOSGridController;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:springTest.xml"})
+@WebAppConfiguration
+public class WMSOSGridControllerTest {
+    static {
+        System.setProperty("biocache.config", System.getProperty("user.dir") + "/src/test/resources/biocache-test-config.properties");
+    }
+
+    @Autowired
+    WMSOSGridController wmsosGridController;
+
+    @Autowired
+    WebApplicationContext wac;
+    MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    // test normal controller handle "text/html", "*/*" in case of exception
+    @Test
+    public void testNormalControllerHTMLException() throws Exception {
+        String[] acceptTypes = new String[] { "text/html", "*/*" };
+        String[][] urls = new String[][] {{"/osgrid/wms/reflect", "/WEB-INF/jsp/error/general.jsp"}};
+
+        for (String[] url : urls) {
+            for (String type : acceptTypes) {
+                // this request generates an exception
+                MvcResult mvcResult = this.mockMvc.perform(get(url[0]).header("Accept", type)
+                        .param("BBOX", "0,0,100,100"))
+                        .andExpect(status().is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR))
+                        .andReturn();
+                assert (mvcResult.getResponse().getForwardedUrl().equals(url[1]));
+            }
+        }
+    }
+
+    // test normal controller handle "application/json" in case of exception
+    @Test
+    public void testNormalControllerJSONException() throws Exception {
+        String acceptType = "application/json";
+        String url = "/osgrid/wms/reflect";
+
+        // this request generates an exception
+        MvcResult mvcResult = this.mockMvc.perform(get(url).header("Accept", acceptType)
+                .param("BBOX", "0,0,100,100"))
+                .andExpect(status().is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR))
+                .andExpect(jsonPath("errorType").exists()).andReturn();
+
+        assert (mvcResult.getResponse().getContentType().contains(MediaType.APPLICATION_JSON_VALUE));
+    }
+}

--- a/src/test/resources/springTest.xml
+++ b/src/test/resources/springTest.xml
@@ -66,8 +66,7 @@
       - is to propagate all exceptions to the servlet container: this will happen
       - here with all other types of exceptions.
      -->
-    <bean class="org.springframework.web.servlet.handler.SimpleMappingExceptionResolver">
-        <property name="exceptionAttribute" value="error"/>
+    <bean class="au.org.ala.biocache.web.CustomExceptionResolver">
         <property name="defaultStatusCode" value="500"/>
         <property name="exceptionMappings">
             <props>


### PR DESCRIPTION
For https://github.com/AtlasOfLivingAustralia/biocache-service/issues/587

`org.springframework.web.servlet.PageNotFound` configured in mainDispatcher-servlet.xml is not an exception so I didn't handle it.

This change provides a custom exception resolver so we can sure the `model` can be converted to JSON when 'application/json' is specified (in this case ContentNegotiaingViewResolver tries to map the whole model into JSON)


I've written an interface to test error page, both /occurrence/test/1 and /test/2 show an error page
```
    @RequestMapping(value = "occurrence/test/{id}", method = RequestMethod.GET)
    public void test(@PathVariable String id) throws Exception {
        if (id.equals("1")) {
            throw new TransactionTimedOutException("alex transaction time out");
            // throw new org.springframework.transaction.TransactionException();
        } else {
            throw new QueryTimeoutException("alex query time out");
            // throw new org.springframework.dao.DataAccessException();
        }
    }
```