### PR TITLE
send 404 when no record found. response body set to JSON.

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -1463,6 +1463,13 @@ public class OccurrenceController extends AbstractSecureController {
         return new String[0];
     }
 
+    private void sendCustomJSONResponse(HttpServletResponse response, int statusCode, Map<String, String> content) throws IOException {
+        response.resetBuffer();
+        response.setStatus(statusCode);
+        response.setHeader("Content-Type", "application/json");
+        response.getOutputStream().print(new org.codehaus.jackson.map.ObjectMapper().writeValueAsString(content));
+        response.flushBuffer();
+    }
     /**
      * Occurrence record page
      * <p>
@@ -1481,12 +1488,14 @@ public class OccurrenceController extends AbstractSecureController {
                           @RequestParam(value = "apiKey", required = false) String apiKey,
                           @RequestParam(value = "im", required = false) String im,
                           HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Object responseObject;
         if (apiKey != null) {
-            return showSensitiveOccurrence(uuid, apiKey, im, request, response);
+            responseObject = showSensitiveOccurrence(uuid, apiKey, im, request, response);
+        } else {
+            responseObject = getOccurrenceInformation(uuid, im, request, false);
         }
-        Object responseObject = getOccurrenceInformation(uuid, im, request, false);
         if (responseObject == null) {
-            response.sendError(404, "Unrecognised ID");
+            sendCustomJSONResponse(response, HttpServletResponse.SC_NOT_FOUND, new HashMap<String, String>() {{put("message", "Unrecognised UID");}});
         }
         return responseObject;
     }
@@ -1516,7 +1525,7 @@ public class OccurrenceController extends AbstractSecureController {
 
         SolrDocumentList sdl = searchDAO.findByFulltext(idRequest);
         if (sdl == null || sdl.isEmpty()) {
-            return new HashMap<>();
+            return null;
         }
 
         SolrDocument sd = sdl.get(0);

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -1467,7 +1467,7 @@ public class OccurrenceController extends AbstractSecureController {
         response.resetBuffer();
         response.setStatus(statusCode);
         response.setHeader("Content-Type", "application/json");
-        response.getOutputStream().print(new org.codehaus.jackson.map.ObjectMapper().writeValueAsString(content));
+        response.getOutputStream().print(new ObjectMapper().writeValueAsString(content));
         response.flushBuffer();
     }
     /**


### PR DESCRIPTION
This is the fix for https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/430

1. `response.sendError(404, "Unrecognised ID")` has a default content type of `txt/html`, a function is created for a `applicaiton/json` type of response and this function can be used for any json handler calling `response.sendError`
2. Biocache-hubs will need change like this 
  
<img width="648" alt="截屏2021-07-12 下午4 59 53" src="https://user-images.githubusercontent.com/61677987/125244433-af121580-e332-11eb-8d6f-95969b27a65b.png">
