### PR TITLE
check if queryParams.getMax() is valid before comparing it with count

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -1234,7 +1234,7 @@ public class SearchDAOImpl implements SearchDAO {
             // or the first rank with the number of facets > 0 when the rank is specified
             for (String r : ranks) {
                 long count = estimateUniqueValues(queryParams, r);
-                if ((count <= queryParams.getMax() && queryParams.getMax() != null && queryParams.getMax() > 0) ||
+                if ((queryParams.getMax() != null && queryParams.getMax() > 0 && count <= queryParams.getMax()) ||
                     (queryParams.getRank() != null && count > 0)) {
                     solrQuery.addFacetField(r);
                     break;


### PR DESCRIPTION
For issue https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/488