### PR TITLE
fixed request.getHeader("X-Forwarded-For") returns multiple ip addres…

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/AbstractSecureController.java
+++ b/src/main/java/au/org/ala/biocache/web/AbstractSecureController.java
@@ -99,14 +99,18 @@ public class AbstractSecureController {
     /**
      * Returns the IP address for the supplied request. It will look for the existence of
      * an X-Forwarded-For Header before extracting it from the request.
+     * X-Forwarded-For Header could contain multiple ip addresses, we only return the original address
+     * https://serverfault.com/questions/846489/can-x-forwarded-for-contain-multiple-ips
      * @param request
      * @return IP Address of the request
      */
     protected String getIPAddress(HttpServletRequest request) {
-
         String ipAddress = request.getHeader("X-Forwarded-For");
-
-        return ipAddress == null ? request.getRemoteAddr(): ipAddress;
+        if (ipAddress == null) {
+            ipAddress = request.getRemoteAddr();
+        }
+        String[] ips = ipAddress.split(",");
+        return (ips.length > 0) ? ips[0].trim() : null;
     }
 
     protected String getUserAgent(HttpServletRequest request) {


### PR DESCRIPTION
…ses.

For https://github.com/AtlasOfLivingAustralia/biocache-service/issues/575

According to https://github.com/AtlasOfLivingAustralia/logger-service/blob/bce9dfecbd29504b2a98e4fd3dc45107ed4c9de7/grails-app/controllers/au/org/ala/logger/IpAddressInterceptor.groovy#L20

and https://serverfault.com/questions/846489/can-x-forwarded-for-contain-multiple-ips

`request.getHeader(X_FORWARDED_FOR)` could return a list of ip addresses separated by `, `. We just need to extract the first one which is the original client ip address.