### PR TITLE
Do not catch Solr exception and convert it normal result. We already …

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAO.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAO.java
@@ -57,7 +57,7 @@ public interface SearchDAO {
      * @return
      * @throws Exception
      */
-    SearchResultDTO findByFulltextSpatialQuery(SpatialSearchRequestParams requestParams, boolean includeSensitive, Map<String, String[]> extraParams);
+    SearchResultDTO findByFulltextSpatialQuery(SpatialSearchRequestParams requestParams, boolean includeSensitive, Map<String, String[]> extraParams) throws Exception;
 
     /**
      * Writes the species count in the specified circle to the output stream.

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -458,35 +458,30 @@ public class SearchDAOImpl implements SearchDAO {
      * @return
      */
     @Override
-    public SearchResultDTO findByFulltextSpatialQuery(SpatialSearchRequestParams searchParams, boolean includeSensitive, Map<String, String[]> extraParams) {
+    public SearchResultDTO findByFulltextSpatialQuery(SpatialSearchRequestParams searchParams,
+                                                      boolean includeSensitive, Map<String, String[]> extraParams) throws Exception {
         SearchResultDTO searchResults = new SearchResultDTO();
         SpatialSearchRequestParams original = new SpatialSearchRequestParams();
         BeanUtils.copyProperties(searchParams, original);
-        try {
-            Map[] fqMaps = queryFormatUtils.formatSearchQuery(searchParams, true);
-            SolrQuery solrQuery = initSolrQuery(searchParams, true, extraParams); // general search settings
+        Map[] fqMaps = queryFormatUtils.formatSearchQuery(searchParams, true);
+        SolrQuery solrQuery = initSolrQuery(searchParams, true, extraParams); // general search settings
 
-            QueryResponse qr = indexDao.runSolrQuery(solrQuery);
+        QueryResponse qr = indexDao.runSolrQuery(solrQuery);
 
-            //need to set the original q to the processed value so that we remove the wkt etc that is added from paramcache object
-            Class resultClass;
-            resultClass = includeSensitive ? au.org.ala.biocache.dto.SensitiveOccurrenceIndex.class : OccurrenceIndex.class;
+        //need to set the original q to the processed value so that we remove the wkt etc that is added from paramcache object
+        Class resultClass;
+        resultClass = includeSensitive ? au.org.ala.biocache.dto.SensitiveOccurrenceIndex.class : OccurrenceIndex.class;
 
-            searchResults = processSolrResponse(original, qr, solrQuery, resultClass);
-            searchResults.setQueryTitle(searchParams.getDisplayString());
-            searchResults.setUrlParameters(original.getUrlParams());
+        searchResults = processSolrResponse(original, qr, solrQuery, resultClass);
+        searchResults.setQueryTitle(searchParams.getDisplayString());
+        searchResults.setUrlParameters(original.getUrlParams());
 
-            //now update the fq display map...
-            searchResults.setActiveFacetMap(fqMaps[0]);
-            searchResults.setActiveFacetObj(fqMaps[1]);
+        //now update the fq display map...
+        searchResults.setActiveFacetMap(fqMaps[0]);
+        searchResults.setActiveFacetObj(fqMaps[1]);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("spatial search query: " + solrQuery.toQueryString());
-            }
-        } catch (Exception ex) {
-            logError("Error executing query with requestParams: " + searchParams.toString(), ex.getMessage());
-            searchResults.setStatus("ERROR"); // TODO also set a message field on this bean with the error message(?)
-            searchResults.setErrorMessage(ex.getMessage());
+        if (logger.isDebugEnabled()) {
+            logger.debug("spatial search query: " + solrQuery.toQueryString());
         }
 
         return searchResults;

--- a/src/main/java/au/org/ala/biocache/util/QidMissingException.java
+++ b/src/main/java/au/org/ala/biocache/util/QidMissingException.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  *
  * @author Adam
  */
-@ResponseStatus(value = HttpStatus.NOT_FOUND)
 public class QidMissingException extends Exception {
      public QidMissingException(String key) {
          super("No stored query available for qid:" + key);

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -678,7 +678,7 @@ public class OccurrenceController extends AbstractSecureController {
      * @param guid
      * @return
      */
-    private NativeDTO getIsAustraliaForGuid(String guid) {
+    private NativeDTO getIsAustraliaForGuid(String guid) throws Exception {
         SpatialSearchRequestParams requestParams = new SpatialSearchRequestParams();
         requestParams.setPageSize(0);
         requestParams.setFacets(new String[]{});
@@ -796,7 +796,7 @@ public class OccurrenceController extends AbstractSecureController {
     @Deprecated
     public @ResponseBody
     SearchResultDTO occurrenceSearchByArea(SpatialSearchRequestParams requestParams,
-                                           Model model) {
+                                           Model model) throws Exception {
         SearchResultDTO searchResult = new SearchResultDTO();
 
         if (StringUtils.isEmpty(requestParams.getQ())) {

--- a/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerIT.java
+++ b/src/test/java/au/org/ala/biocache/controller/WMSOSGridControllerIT.java
@@ -1,16 +1,22 @@
 package au.org.ala.biocache.controller;
 
+import au.org.ala.biocache.dao.SearchDAO;
+import au.org.ala.biocache.util.QidMissingException;
 import au.org.ala.biocache.util.SolrUtils;
 import au.org.ala.biocache.web.WMSOSGridController;
+import junit.framework.TestCase;
+import org.apache.solr.common.SolrException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -18,6 +24,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpServletResponse;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,13 +33,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:springTest.xml"})
 @WebAppConfiguration
-public class WMSOSGridControllerIT {
+public class WMSOSGridControllerIT extends TestCase {
     static {
         System.setProperty("biocache.config", System.getProperty("user.dir") + "/src/test/resources/biocache-test-config.properties");
     }
 
     @Autowired
     WMSOSGridController wmsosGridController;
+
+    SearchDAO searchDAO;
 
     @Autowired
     WebApplicationContext wac;
@@ -43,33 +53,88 @@ public class WMSOSGridControllerIT {
     }
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        searchDAO = mock(SearchDAO.class);
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
 
-    // test normal controller handle "text/html", "*/*" in case of exception
+    private Object backupSearchDAO() {
+        Object searchDAOOrig = ReflectionTestUtils.getField(wmsosGridController, "searchDAO");
+        ReflectionTestUtils.setField(wmsosGridController, "searchDAO", searchDAO);
+        return searchDAOOrig;
+    }
+
+    private void restoreSearchDAO(Object object) {
+        ReflectionTestUtils.setField(wmsosGridController, "searchDAO", object);
+    }
+
+    // test normal controller handle "text/html", "*/*" in case of QidMissingException exception
     @Test
-    public void testNormalControllerHTMLException() throws Exception {
+    public void testNormalControllerHTMLQidMissingException() throws Exception {
+        Object searchDAOOrig = backupSearchDAO();
         String[] acceptTypes = new String[] { "text/html", "*/*" };
         String[][] urls = new String[][] {{"/osgrid/wms/reflect", "/WEB-INF/jsp/error/general.jsp"}};
 
+        when(this.searchDAO.findByFulltextSpatialQuery(Mockito.any(), Mockito.anyBoolean(), Mockito.anyMap())).thenThrow(new QidMissingException("qidmissing"));
         for (String[] url : urls) {
             for (String type : acceptTypes) {
                 // this request generates an exception
                 MvcResult mvcResult = this.mockMvc.perform(get(url[0]).header("Accept", type)
                         .param("BBOX", "0,0,100,100"))
-                        .andExpect(status().is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR))
+                        .andExpect(status().is(HttpServletResponse.SC_BAD_REQUEST))
                         .andReturn();
                 assert (mvcResult.getResponse().getForwardedUrl().equals(url[1]));
             }
         }
+        restoreSearchDAO(searchDAOOrig);
     }
 
-    // test normal controller handle "application/json" in case of exception
+    // test normal controller handle "text/html", "*/*" in case of SolrException exception
     @Test
-    public void testNormalControllerJSONException() throws Exception {
+    public void testNormalControllerHTMLSolrException() throws Exception {
+        Object searchDAOOrig = backupSearchDAO();
+        String[] acceptTypes = new String[] { "text/html", "*/*" };
+        String[][] urls = new String[][] {{"/osgrid/wms/reflect", "/WEB-INF/jsp/error/general.jsp"}};
+
+        when(this.searchDAO.findByFulltextSpatialQuery(Mockito.any(), Mockito.anyBoolean(), Mockito.anyMap())).thenThrow(new SolrException(SolrException.ErrorCode.NOT_FOUND, "qidmissing"));
+        for (String[] url : urls) {
+            for (String type : acceptTypes) {
+                // this request generates an exception
+                MvcResult mvcResult = this.mockMvc.perform(get(url[0]).header("Accept", type)
+                        .param("BBOX", "0,0,100,100"))
+                        .andExpect(status().is(HttpServletResponse.SC_NOT_FOUND))
+                        .andReturn();
+                assert (mvcResult.getResponse().getForwardedUrl().equals(url[1]));
+            }
+        }
+        restoreSearchDAO(searchDAOOrig);
+    }
+
+    // test normal controller handle "application/json" in case of QidMissingException exception
+    @Test
+    public void testNormalControllerJSONQidMissingException() throws Exception {
+        Object searchDAOOrig = backupSearchDAO();
         String acceptType = "application/json";
         String url = "/osgrid/wms/reflect";
+        when(this.searchDAO.findByFulltextSpatialQuery(Mockito.any(), Mockito.anyBoolean(), Mockito.anyMap())).thenThrow(new QidMissingException("qidmissing"));
+
+        // this request generates an exception
+        MvcResult mvcResult = this.mockMvc.perform(get(url).header("Accept", acceptType)
+                .param("BBOX", "0,0,100,100"))
+                .andExpect(status().is(HttpServletResponse.SC_BAD_REQUEST))
+                .andExpect(jsonPath("errorType").exists()).andReturn();
+
+        assert (mvcResult.getResponse().getContentType().contains(MediaType.APPLICATION_JSON_VALUE));
+        restoreSearchDAO(searchDAOOrig);
+    }
+
+    // test normal controller handle "application/json" in case of SolrException exception
+    @Test
+    public void testNormalControllerJSONSolrException() throws Exception {
+        Object searchDAOOrig = backupSearchDAO();
+        String acceptType = "application/json";
+        String url = "/osgrid/wms/reflect";
+        when(this.searchDAO.findByFulltextSpatialQuery(Mockito.any(), Mockito.anyBoolean(), Mockito.anyMap())).thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR, "qidmissing"));
 
         // this request generates an exception
         MvcResult mvcResult = this.mockMvc.perform(get(url).header("Accept", acceptType)
@@ -78,5 +143,6 @@ public class WMSOSGridControllerIT {
                 .andExpect(jsonPath("errorType").exists()).andReturn();
 
         assert (mvcResult.getResponse().getContentType().contains(MediaType.APPLICATION_JSON_VALUE));
+        restoreSearchDAO(searchDAOOrig);
     }
 }


### PR DESCRIPTION
…have a customExceptionResolver which can set HTTP status code according to Solr error type.


for issue 522 https://github.com/AtlasOfLivingAustralia/biocache-service/issues/522

**So now the response will like these:**
<img width="1134" alt="Screen Shot 2021-08-20 at 11 31 12 am" src="https://user-images.githubusercontent.com/61677987/130167143-7b64f042-9e63-49db-a323-26205e2af90e.png">

<img width="1370" alt="Screen Shot 2021-08-20 at 11 31 50 am" src="https://user-images.githubusercontent.com/61677987/130167157-698249e7-953f-4aee-a532-8f2d75f6ad4a.png">

**Removing the `try {} catch` makes the function possibly throw QidMissingException. It is also handled** <br/>Before the change if a qid is not found, it's like this
<img width="618" alt="Screen Shot 2021-08-20 at 12 07 51 pm" src="https://user-images.githubusercontent.com/61677987/130168006-e685492c-158f-4446-aa3f-696353546d76.png">

**Now after the change it's like**


<img width="917" alt="Screen Shot 2021-08-20 at 11 20 43 am" src="https://user-images.githubusercontent.com/61677987/130167363-ae2b1e1a-12a7-4a39-818d-1fe7143c8570.png">
<img width="1362" alt="Screen Shot 2021-08-20 at 11 21 13 am" src="https://user-images.githubusercontent.com/61677987/130167370-ee13c468-e1f2-4fa6-80f0-27941219516b.png">

