### PR TITLE
processed eventDate not returned with occurrence

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -1728,6 +1728,12 @@ public class OccurrenceController extends AbstractSecureController {
 
             LocalDate localDate = ((Date) value).toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
             map.put(fieldNameToUse, localDate.toString());
+
+        } else if (value != null) {
+
+            // If the value is not a date add without parsing to date.
+            // Note: raw (unprocessed) fields are stored as string values.
+            addField(sd, map, fieldNameToUse, fieldName);
         }
     }
 


### PR DESCRIPTION
The processed `raw_eventDate` value was not being returned with the occurrence JSON data. 

The issue was related to a check `value instanceof Date` when adding the eventDate value to the JSON, since the `raw_eventDate` field type is a string the date was not added. 

AtlasOfLivingAustralia/la-pipelines#504