### PR TITLE
fixed getByCode(int code) which returns null for user assertions code

### DIFF
--- a/src/main/java/au/org/ala/biocache/dto/AssertionCodes.java
+++ b/src/main/java/au/org/ala/biocache/dto/AssertionCodes.java
@@ -4,6 +4,7 @@ import org.gbif.api.vocabulary.InterpretationRemarkSeverity;
 import org.gbif.api.vocabulary.OccurrenceIssue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -42,7 +43,7 @@ public class AssertionCodes {
     static final public List<ErrorCode> allAssertionCodes = new ArrayList<>();
 
     static {
-
+        allAssertionCodes.addAll(Arrays.asList(userAssertionCodes));
         ALAOccurrenceIssue[] alaIssues = ALAOccurrenceIssue.values();
         OccurrenceIssue[] issues = OccurrenceIssue.values();
 

--- a/src/main/java/au/org/ala/biocache/dto/QualityAssertion.java
+++ b/src/main/java/au/org/ala/biocache/dto/QualityAssertion.java
@@ -85,7 +85,7 @@ public class QualityAssertion {
 
     public void setCode(Integer code) {
         this.code = code;
-        if (name == null) {
+        if (name == null && code != null) {
             ErrorCode errorCode = AssertionCodes.getByCode(code);
             if (errorCode != null) {
                 name = errorCode.getName();

--- a/src/main/java/au/org/ala/biocache/service/AssertionService.java
+++ b/src/main/java/au/org/ala/biocache/service/AssertionService.java
@@ -141,6 +141,7 @@ public class AssertionService {
             if (qa.getUuid().equals(assertionUuid)) {
                 // do not return the snapshot
                 qa.setSnapshot(null);
+                qa.setCode(qa.getCode());
                 return qa;
             }
         }
@@ -151,6 +152,7 @@ public class AssertionService {
         UserAssertions userAssertions = store.get(UserAssertions.class, recordUuid).orElse(new UserAssertions());
         for (QualityAssertion qa : userAssertions) {
             qa.setSnapshot(null);
+            qa.setCode(qa.getCode());
         }
         return userAssertions;
     }


### PR DESCRIPTION
for issue https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/504

there must be some assertions written into database with empty name, so I call `qa.setCode`  to populate name when `getAssertion` is called.

