### PR TITLE
formatting of recordedBy multi-value download results

### DIFF
--- a/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
+++ b/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
@@ -21,6 +21,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static au.org.ala.biocache.dto.OccurrenceIndex.*;
 
@@ -190,21 +192,18 @@ public class ProcessDownload implements ProcessInterface {
         // post-process fields requested are headers.included[pos] where pos >= headers.labels.length
         for (int j = 0; j < headers.labels.length; j++) {
             Object obj = tuple.get(headers.included[j]);
-            if (obj == null) {
-                values[j] = "";
-            } else if (obj instanceof Collection) {
-                Iterator it = ((Collection) obj).iterator();
-                while (it.hasNext()) {
-                    Object value = it.next();
-                    if (values[j] != null && values[j].length() > 0) values[j] += "|"; //multivalue separator
-                    values[j] = SearchUtils.formatValue(value);
+            values[j] = "";
+            if (obj instanceof Collection) {
 
-                    //allow requests to include multiple values when requested
-                    if (!includeMultivalues) {
-                        break;
-                    }
+                Stream objStream = ((Collection) obj).stream();
+
+                if (!includeMultivalues) {
+                    objStream = objStream.limit(1);
                 }
-            } else {
+
+                values[j] = (String) objStream.map(SearchUtils::formatValue).collect(Collectors.joining(" | "));
+
+            } else if (obj != null) {
                 values[j] = SearchUtils.formatValue(obj);
             }
         }

--- a/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
+++ b/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
@@ -192,8 +192,10 @@ public class ProcessDownload implements ProcessInterface {
         // post-process fields requested are headers.included[pos] where pos >= headers.labels.length
         for (int j = 0; j < headers.labels.length; j++) {
             Object obj = tuple.get(headers.included[j]);
-            values[j] = "";
-            if (obj instanceof Collection) {
+
+            if (obj == null) {
+                values[j] = "";
+            } else if (obj instanceof Collection) {
 
                 Stream objStream = ((Collection) obj).stream();
 
@@ -203,7 +205,7 @@ public class ProcessDownload implements ProcessInterface {
 
                 values[j] = (String) objStream.map(SearchUtils::formatValue).collect(Collectors.joining(" | "));
 
-            } else if (obj != null) {
+            } else {
                 values[j] = SearchUtils.formatValue(obj);
             }
         }


### PR DESCRIPTION
Bug fix when processing multi-value field results. The last multi-value result would overwrite the appended values. 

see: AtlasOfLivingAustralia/biocache-hubs#507