### PR TITLE
removed the inclusion of javax.mail 1.5.0, so javax.mail 1.6.2 in jav…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,12 +345,6 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- javax.mail to match dependency in gt-refrencing -->
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.5.0</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>


### PR DESCRIPTION
…aee-api:jar:8.0.1 will be used

for #699 

With this change, javax.mail 1.6.2 will be used. Email can be sent out from test server.

`mvn dependency:tree` shows the only difference before/after the change is:

```
[INFO] +- com.sun.mail:javax.mail:jar:1.5.0:compile
[INFO] |  \- javax.activation:activation:jar:1.1:compile
```

to

```
[INFO] |  \- com.sun.mail:javax.mail:jar:1.6.2:compile
[INFO] |     \- javax.activation:activation:jar:1.1:compile
```
