### PR TITLE
truncated download results

### DIFF
--- a/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
+++ b/src/main/java/au/org/ala/biocache/stream/ProcessDownload.java
@@ -310,22 +310,26 @@ public class ProcessDownload implements ProcessInterface {
         // maintain miscFields order using synchronized
         synchronized (miscFields) {
             // append known miscField values
-            String json = SearchUtils.formatValue(tuple.getString(OccurrenceIndex.MISC));
+            String json = SearchUtils.formatValue(tuple.get(OccurrenceIndex.MISC));
             if (StringUtils.isNotEmpty(json)) {
-                JSONObject jo = JSONObject.fromObject(json);
-                for (String f : miscFields) {
-                    values[offset] = SearchUtils.formatValue(jo.get(f));
-                    offset++;
+                try {
+                    JSONObject jo = JSONObject.fromObject(json);
+                    for (String f : miscFields) {
+                        values[offset] = SearchUtils.formatValue(jo.get(f));
+                        offset++;
 
-                    jo.remove(f);
-                }
-                // find and append new miscFields and their values
-                for (Object entry : jo.entrySet()) {
-                    String value = SearchUtils.formatValue(((Map.Entry) entry).getValue());
-                    if (StringUtils.isNotEmpty(value)) {
-                        miscValues.add(value);
-                        miscFields.add((String) ((Map.Entry) entry).getKey());
+                        jo.remove(f);
                     }
+                    // find and append new miscFields and their values
+                    for (Object entry : jo.entrySet()) {
+                        String value = SearchUtils.formatValue(((Map.Entry) entry).getValue());
+                        if (StringUtils.isNotEmpty(value)) {
+                            miscValues.add(value);
+                            miscFields.add((String) ((Map.Entry) entry).getKey());
+                        }
+                    }
+                } catch (Exception e) {
+                    // ignore malformed dynamicProperties
                 }
             }
         }


### PR DESCRIPTION
The truncated download are caused by errors when processing the `dynamicProperties`

1. `Tuple::getString` returns the string "null" for null values which fail to parse as json
  use `Tuple::get` will resolve to empty string `SearchUtils::formatValue`

2. malformed (unparsable json)`dynamicProperties` value
 catch parse error and ignore 

AtlasOfLivingAustralia/biocache-service#692