### PR TITLE
Backport Heatmap fix in 2.7.x

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/SearchDAO.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAO.java
@@ -451,4 +451,21 @@ public interface SearchDAO {
      * @return
      */
     List<String> listFacets(SpatialSearchRequestParams searchParams) throws Exception;
+
+    /**
+     * Query for heatmaps.
+     *
+     * @param query
+     * @param filterQueries
+     * @param minx
+     * @param miny
+     * @param maxx
+     * @param maxy
+     * @param legend
+     * @return
+     * @throws Exception
+     */
+    HeatmapDTO getHeatMap(String query, String[] filterQueries, Double minx, Double miny, Double maxx, Double maxy,
+                          List<LegendItem> legend,
+                          int gridSize) throws Exception;
 }

--- a/src/main/java/au/org/ala/biocache/dto/HeatmapDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/HeatmapDTO.java
@@ -1,0 +1,65 @@
+package au.org.ala.biocache.dto;
+
+import au.org.ala.biocache.util.LegendItem;
+
+import java.util.List;
+
+public class HeatmapDTO {
+
+    public final Integer gridLevel;
+    // each element of the list is a single grid layer
+    public final List<List<List<Integer>>> layers;
+    public final List<LegendItem> legend;
+    public final int gridSizeInPixels;
+    public final Integer rows;
+    public final Integer columns;
+    public final Double minx;
+    public final Double miny;
+    public final Double maxx;
+    public final Double maxy;
+    public  Double tileMinx;
+    public  Double tileMiny;
+    public  Double tileMaxx;
+    public  Double tileMaxy;
+
+    public HeatmapDTO(Integer gridLevel, List<List<List<Integer>>> layers, List<LegendItem> legend, int gridSizeInPixels, Integer rows, Integer columns, Double minx, Double miny, Double maxx, Double maxy) {
+        // adjust for dateline wrap
+        while (minx >= 180)
+            minx = minx - 360.0;
+        while (maxx <= -180)
+            maxx = maxx + 360.0;
+        if (minx > maxx)
+            maxx = maxx + 360;
+
+        this.gridLevel = gridLevel;
+        this.layers = layers;
+        this.legend = legend;
+        this.gridSizeInPixels = gridSizeInPixels;
+        this.rows = rows;
+        this.columns = columns;
+        this.minx = minx;
+        this.miny = miny;
+        this.maxx = maxx;
+        this.maxy = maxy;
+
+        // default tile extents
+        this.tileMinx = minx;
+        this.tileMaxy = miny;
+        this.tileMaxx = maxx;
+        this.tileMaxy = maxy;
+    }
+    public Double columnWidth() {
+        return (maxx - minx) / (double) columns;
+    }
+
+    public Double rowHeight() {
+        return (maxy - miny) / (double) rows;
+    }
+
+    public void setTileExtents(double[] bbox) {
+        tileMinx = bbox[0];
+        tileMiny = bbox[1];
+        tileMaxx = bbox[2];
+        tileMaxy = bbox[3];
+    }
+}

--- a/src/main/java/au/org/ala/biocache/util/LegendItem.java
+++ b/src/main/java/au/org/ala/biocache/util/LegendItem.java
@@ -23,19 +23,37 @@ public class LegendItem implements Comparable<LegendItem> {
 
     String name;
     String i18nCode;
+    String facetValue;
     long count;
     int colour;
     String fq;
     int red;
     int blue;
     int green;
-
+    boolean remainder = false;
 
     public LegendItem(String name, String i18nCode, long count, String fq) {
         this.name = name != null ? name : "";
         this.i18nCode = i18nCode;
         this.count = count;
         this.fq = fq;
+    }
+    
+    public LegendItem(String name, String i18nCode, String facetValue, long count, String fq) {
+        this.name = name != null ? name : "";
+        this.facetValue = facetValue;
+        this.i18nCode = i18nCode;
+        this.count = count;
+        this.fq = fq;
+    }
+
+    public LegendItem(String name, String i18nCode,  String facetValue, long count, String fq, boolean remainder) {
+        this.name = name != null ? name : "";
+        this.i18nCode = i18nCode;
+        this.facetValue = facetValue;
+        this.count = count;
+        this.fq = fq;
+        this.remainder = remainder;
     }
 
     public void setRGB(int colour) {
@@ -67,6 +85,7 @@ public class LegendItem implements Comparable<LegendItem> {
     
     public void setColour(int colour) {
         this.colour = colour;
+        setRGB(colour);
     }
     
     public int getColour() {
@@ -94,6 +113,22 @@ public class LegendItem implements Comparable<LegendItem> {
         return green;
     }
 
+
+    public boolean isRemainder() {
+        return remainder;
+    }
+
+    public void setRemainder(boolean remainder) {
+        this.remainder = remainder;
+    }
+
+    public String getFacetValue() {
+        return facetValue;
+    }
+
+    public void setFacetValue(String facetValue) {
+        this.facetValue = facetValue;
+    }
     /**
      * Sort 'count', descending, then 'name' ascending.
      * @param o
@@ -101,6 +136,12 @@ public class LegendItem implements Comparable<LegendItem> {
      */
     @Override
     public int compareTo(LegendItem o) {
+        if (remainder){
+            return 1000;
+        }
+        if (o.remainder){
+            return -1000;
+        }
         long c = count - o.count;
         if(c == 0) {
            if(name == null && o.name == null) {

--- a/src/main/webapp/WEB-INF/ehcache.xml
+++ b/src/main/webapp/WEB-INF/ehcache.xml
@@ -6,6 +6,7 @@
     <cache name="legendCache" maxElementsInMemory="2000" eternal="false" overflowToDisk="false"/>
     <cache name="getColours" maxElementsInMemory="2000" eternal="false" overflowToDisk="false"/>
     <cache name="fixWkt" maxElementsInMemory="100" eternal="false" overflowToDisk="false"/>
+    <cache name="heatmapCache" maxElementsInMemory="2000" eternal="false" overflowToDisk="false" timeToLiveSeconds="1800"/>
     <cache name="speciesListItems" maxElementsInMemory="1000" eternal="false" overflowToDisk="false"/>
     <cache name="speciesKvp" maxElementsInMemory="1000" eternal="false" overflowToDisk="false"/>
     <cache name="qidGeneration" maxElementsInMemory="1000" eternal="false" overflowToDisk="false" />


### PR DESCRIPTION
This PR is the backport in branch 2.7.x of the heatmap fix done by ALA in 3.x

This backport has been tested (and is in production in France: https://openobs.mnhn.fr) on a 2.5.x branch.

This 2.7.x backport is similar to the 2.5.x but it was NOT tested because 2.7.x is not compatible with my current ALA deployment.

REMINDER: it has some requirements in term of SolR version and the schema should contains the "quad" field
Maybe we should create a separated 2.7.x branch?

```
<fieldType name="geohash"
               class="solr.SpatialRecursivePrefixTreeFieldType"
               datelineRule="ccwRect"
               spatialContextFactory="org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory"
               validationRule="none"
               distanceUnits="degrees"
               autoIndex="true"
    />
    <fieldType name="quad"
               class="solr.SpatialRecursivePrefixTreeFieldType"
               datelineRule="ccwRect"
               spatialContextFactory="org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory"
               validationRule="none"
               distanceUnits="degrees"
               prefixTree="quad"
               autoIndex="true"
    />
    <fieldType name="packedQuad"
               class="solr.SpatialRecursivePrefixTreeFieldType"
               datelineRule="ccwRect"
               spatialContextFactory="org.locationtech.spatial4j.context.jts.JtsSpatialContextFactory"
               validationRule="none"
               distanceUnits="degrees"
               prefixTree="packedQuad"
               autoIndex="true"
    />

    <field name="geohash"       type="geohash"     indexed="true"/>
    <field name="quad"          type="quad"        indexed="true"/>
    <field name="packedQuad"    type="packedQuad"  indexed="true"/>
```


