### PR TITLE
Remove fq delimiting by comma

### DIFF
--- a/src/main/java/au/org/ala/biocache/config/AppConfig.java
+++ b/src/main/java/au/org/ala/biocache/config/AppConfig.java
@@ -3,6 +3,7 @@ package au.org.ala.biocache.config;
 import au.org.ala.biocache.service.NameMatchSpeciesLookupService;
 import au.org.ala.biocache.service.RestartDataService;
 import au.org.ala.biocache.service.SpeciesLookupService;
+import au.org.ala.biocache.util.converter.FqConverter;
 import au.org.ala.dataquality.api.QualityServiceRpcApi;
 import au.org.ala.dataquality.client.ApiClient;
 import au.org.ala.names.ws.client.ALANameUsageMatchServiceClient;
@@ -12,6 +13,7 @@ import org.apache.log4j.Logger;
 import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -119,5 +121,11 @@ public class AppConfig implements WebMvcConfigurer {
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addRedirectViewController("/", "/swagger-ui.html");
+    }
+
+    @Bean
+    @ConfigurationPropertiesBinding
+    public FqConverter delimitedStringToArrayConverter() {
+        return new FqConverter();
     }
 }

--- a/src/main/java/au/org/ala/biocache/config/AppConfig.java
+++ b/src/main/java/au/org/ala/biocache/config/AppConfig.java
@@ -125,7 +125,7 @@ public class AppConfig implements WebMvcConfigurer {
 
     @Bean
     @ConfigurationPropertiesBinding
-    public FqConverter delimitedStringToArrayConverter() {
+    public FqConverter fqConverter() {
         return new FqConverter();
     }
 }

--- a/src/main/java/au/org/ala/biocache/dto/SpatialSearchRequestParams.java
+++ b/src/main/java/au/org/ala/biocache/dto/SpatialSearchRequestParams.java
@@ -14,6 +14,7 @@
  ***************************************************************************/
 package au.org.ala.biocache.dto;
 
+import au.org.ala.biocache.util.converter.FqField;
 import au.org.ala.biocache.validate.ValidSpatialParams;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -39,6 +40,7 @@ public class SpatialSearchRequestParams {
     @Parameter(name="q", description = "Main search query. Examples 'q=Kangaroo' or 'q=vernacularName:red'")
     protected String q = "*:*";
 
+    @FqField()
     @Parameter(name="fq", description = "Filter queries. " +
             "Examples 'fq=state:Victoria&fq=state:Queensland")
     protected String[] fq = {}; // must not be null

--- a/src/main/java/au/org/ala/biocache/util/converter/FqConverter.java
+++ b/src/main/java/au/org/ala/biocache/util/converter/FqConverter.java
@@ -1,0 +1,31 @@
+package au.org.ala.biocache.util.converter;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+
+import java.util.Set;
+
+/**
+ * Only for use by the `fq` URL parameter. Only applies to fields annotated with `FqField` and requiring
+ * `String` to `String[]` conversion.
+ *
+ * Overrides the default behaviour of WebConversionService where URL parameters are split by `,` when there is
+ * only a single term and the target is an array.
+ */
+public class FqConverter implements ConditionalGenericConverter {
+
+        public Set<ConvertiblePair> getConvertibleTypes() {
+            // Returning null to add this converter to the global pool of converters, making it apply before non-global.
+            return null;
+        }
+
+        public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+            return (targetType.hasAnnotation(FqField.class) &&
+                            "java.lang.String".equals(sourceType.getName()) &&
+                            "java.lang.String[]".equals(targetType.getName()));
+        }
+
+        public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+            return source == null ? null : new String[] { source.toString() };
+        }
+    }

--- a/src/main/java/au/org/ala/biocache/util/converter/FqField.java
+++ b/src/main/java/au/org/ala/biocache/util/converter/FqField.java
@@ -1,0 +1,9 @@
+package au.org.ala.biocache.util.converter;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface FqField {
+}

--- a/src/main/java/au/org/ala/biocache/web/AutocompleteController.java
+++ b/src/main/java/au/org/ala/biocache/web/AutocompleteController.java
@@ -15,6 +15,7 @@
 package au.org.ala.biocache.web;
 
 import au.org.ala.biocache.service.SpeciesLookupService;
+import au.org.ala.biocache.util.converter.FqField;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,7 +44,7 @@ public class AutocompleteController extends AbstractSecureController {
     @ResponseBody
     Map search(
             @RequestParam(value = "q") String query,
-            @RequestParam(value = "fq", required = false) String[] filterQuery,
+            @FqField @RequestParam(value = "fq", required = false) String[] filterQuery,
             @RequestParam(value = "pageSize", required = false, defaultValue = "10") Integer max,
             @RequestParam(value = "all", required = false, defaultValue = "false") Boolean includeAll,
             @RequestParam(value = "synonyms", required = false, defaultValue = "true") Boolean searchSynonyms,

--- a/src/main/java/au/org/ala/biocache/web/DeprecatedController.java
+++ b/src/main/java/au/org/ala/biocache/web/DeprecatedController.java
@@ -3,6 +3,7 @@ package au.org.ala.biocache.web;
 import au.org.ala.biocache.dto.DownloadRequestParams;
 import au.org.ala.biocache.dto.SpatialSearchRequestParams;
 import au.org.ala.biocache.dto.TaxaCountDTO;
+import au.org.ala.biocache.util.converter.FqField;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.ui.Model;
@@ -30,7 +31,7 @@ public class DeprecatedController {
     public @ResponseBody
     Map<String, Integer> occurrenceSpeciesCounts(
             @RequestParam(value = "listOfGuids", required = true, defaultValue = "") String listOfGuids,
-            @RequestParam(value = "fq", required = false) String[] filterQueries,
+            @FqField @RequestParam(value = "fq", required = false) String[] filterQueries,
             @RequestParam(defaultValue = "\n") String separator,
             HttpServletResponse response,
             HttpServletRequest request

--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -26,6 +26,7 @@ import au.org.ala.biocache.service.*;
 import au.org.ala.biocache.util.OccurrenceUtils;
 import au.org.ala.biocache.util.QidSizeException;
 import au.org.ala.biocache.util.SearchUtils;
+import au.org.ala.biocache.util.converter.FqField;
 import au.org.ala.ws.security.profile.AlaUserProfile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -1180,7 +1181,7 @@ public class OccurrenceController extends AbstractSecureController {
             method = {RequestMethod.POST, RequestMethod.GET}, produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody Map<String, Integer> occurrenceSpeciesCounts(
             @Parameter(description = "taxonConceptIDs, newline separated (by default)") @RequestParam(name="guids") String listOfGuids,
-            @RequestParam(value = "fq", required = false) String[] filterQueries,
+            @FqField @RequestParam(value = "fq", required = false) String[] filterQueries,
             @RequestParam(defaultValue = "\n") String separator,
             HttpServletResponse response
     ) throws Exception {

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -20,6 +20,7 @@ import au.org.ala.biocache.dao.TaxonDAO;
 import au.org.ala.biocache.dto.*;
 import au.org.ala.biocache.stream.StreamAsCSV;
 import au.org.ala.biocache.util.*;
+import au.org.ala.biocache.util.converter.FqField;
 import au.org.ala.biocache.util.solr.FieldMappingUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1190,7 +1191,7 @@ public class WMSController extends AbstractSecureController {
             @RequestParam(value = "OUTLINECOLOUR", required = false, defaultValue = "0x000000") String outlineColour,
             @RequestParam(value = "LAYERS", required = false, defaultValue = "") String layers,
             @RequestParam(value = "q", required = false, defaultValue = "*:*") String query,
-            @RequestParam(value = "fq", required = false) String[] filterQueries,
+            @FqField @RequestParam(value = "fq", required = false) String[] filterQueries,
             @RequestParam(value = "X", required = false, defaultValue = "0") Double x,
             @RequestParam(value = "Y", required = false, defaultValue = "0") Double y,
             @RequestParam(value = "GRIDDETAIL", required = false, defaultValue = "16") int gridDivisionCount,


### PR DESCRIPTION
https://github.com/AtlasOfLivingAustralia/biocache-service/issues/778

This fixes the use case of a request with only one fq parameter and it just happens to contain a comma. e.g. `https://biocache.ala.org.au/occurrences/search?q=taxa%3A%22Geophila%22&qualityProfile=ALA&fq=collector%3A%22Forster%2C+P.I.%22`