### PR TITLE
fix for qid creation error

### DIFF
--- a/src/main/java/au/org/ala/biocache/dao/QidCacheDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/QidCacheDAOImpl.java
@@ -448,7 +448,12 @@ public class QidCacheDAOImpl implements QidCacheDAO {
             //get bbox (also cleans up Q)
             double[] bb = null;
             if (bbox != null && bbox.equals("true")) {
-                bb = searchDAO.getBBox(requestParams);
+                try {
+                    bb = searchDAO.getBBox(requestParams);
+                } catch (Exception e) {
+                    // When there are no occurrences for the query return a usable bounding box
+                    bb = new double []{-180, -90, 180, 90};
+                }
             } else {
                 requestParams.setPageSize(0);
                 requestParams.setFacet(false);


### PR DESCRIPTION
A fix for the error thrown when creating a qid using `bbox=true` and all occurrences in the query are missing longitude or latitude.