### PR TITLE
Add materialSampleID to occurrence record endpoint

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -2128,6 +2128,7 @@ public class OccurrenceController extends AbstractSecureController {
         addField(sd, occurrence, "institutionID", getFieldName);
         addField(sd, occurrence, "language", getFieldName);
         addField(sd, occurrence, "lifeStage", getFieldName);
+        addField(sd, occurrence, "materialSampleID", getFieldName);
         addField(sd, occurrence, "modified", getFieldName);
         addField(sd, occurrence, "occurrenceAttributes", getFieldName);
         addField(sd, occurrence, "occurrenceDetails", getFieldName);


### PR DESCRIPTION
Adds `materialSampleID` to the occurrence record endpoint. Adding it here will also make it (automatically) appear on the occurrence record ui page in the ala-hub.