### PR TITLE
Prevent parsing of facets in response from crashing request

### DIFF
--- a/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
+++ b/src/main/java/au/org/ala/biocache/util/QueryFormatUtils.java
@@ -178,7 +178,11 @@ public class QueryFormatUtils {
                                 facet.setName(fv[0]);
                                 facet.setValue(fqOriginal.substring(fv[0].length() + 1));
                             }
-                            activeFacetMap.put(facet.getName(), facet);
+                            if (facet.getName() != null)  {
+                                activeFacetMap.put(facet.getName(), facet);
+                            } else {
+                                logger.error("Unable to parse facet name from fq, ignoring: " + fq);
+                            }
 
                             // activeFacetMap is based on the assumption that each fq is on different filter so its a [StringKey: Facet] structure
                             // but actually different fqs can use same filter key for example &fq=-month:'11'&fq=-month='12' so we added a new map


### PR DESCRIPTION
I had a strange error on the latest develop branch.
The search results would return the proper JSON object, but also a 500 internal error status.

The issue was that when writing the json response, it encountered a "null" key in the active asset map when serializing the response.

The parsing seems to fail, because the facet name is found by splitting using the ':' character.
In my debugging, I found that the values where URL-encoded however, replacing ':' with '%3A'.
Making the split not work and a null value for name used as a key.

I am not really sure what the activeFacetMap is supposed to do or behave.
So I did not try to fix the underlying issue.

It does seem prudent however to add a check that allows for slightly more graceful failure?