### PR TITLE
Add sampleSizeValue and sampleSizeUnit to occurrence endpoint

### DIFF
--- a/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
+++ b/src/main/java/au/org/ala/biocache/web/OccurrenceController.java
@@ -2354,6 +2354,8 @@ public class OccurrenceController extends AbstractSecureController {
         addField(sd, event, "startYear", getFieldName);
         addField(sd, event, "endYear", getFieldName);
         addField(sd, event, "datePrecision", getFieldName);
+        addField(sd, event, "sampleSizeValue", getFieldName);
+        addField(sd, event, "sampleSizeUnit", getFieldName);
 
         // au.org.ala.biocache.model.Attribution
         Map attribution = new HashMap();


### PR DESCRIPTION
Adds `sampleSizeValue` and `sampleSizeUnit`  to the occurrence record endpoint. Adding it here will also make it (automatically) appear on the occurrence record ui page in the ala-hub. (This is similar to https://github.com/AtlasOfLivingAustralia/biocache-service/pull/928)