### PR TITLE
Allow running multiple instances in the same tomcat

### DIFF
--- a/src/main/resources/spring.xml
+++ b/src/main/resources/spring.xml
@@ -95,6 +95,7 @@
     <bean id="ehCacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
         <property name="configLocation"  value="/WEB-INF/ehcache.xml"/>
         <property name="shared" value="true" />
+        <property name="cacheManagerName" value="${spring.application.name}-cachemanager"/>
     </bean>
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager">

--- a/src/main/resources/spring.xml
+++ b/src/main/resources/spring.xml
@@ -95,7 +95,7 @@
     <bean id="ehCacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
         <property name="configLocation"  value="/WEB-INF/ehcache.xml"/>
         <property name="shared" value="true" />
-        <property name="cacheManagerName" value="${spring.application.name}-cachemanager"/>
+        <property name="cacheManagerName" value="${spring.application.name:biocache-service}-cachemanager"/>
     </bean>
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager">


### PR DESCRIPTION
Trying to run both a sandbox-service and biocache-service in a single tomcat instance resulted in a bean name conflict.
This small fix should prevent that.