### PR TITLE
Add Support for Role Based Access Control

### DIFF
--- a/config/biocache-config.properties
+++ b/config/biocache-config.properties
@@ -219,3 +219,6 @@ shapefile.tmp.dir=/data/biocache-download/tmp
 
 # Append DwC links to descriptions of dwcTerm fields. Leave empty to disable.
 dwc.url=http://rs.tdwg.org/dwc/terms/
+
+rbac.enabled=false
+rbac.rolePrefix=DATA_

--- a/solr/conf/managed-schema
+++ b/solr/conf/managed-schema
@@ -751,4 +751,8 @@
        as not to throw an error. No data will be added to this field.  -->
   <field name="null" type="string" docValues="true" indexed="true" stored="true"/>
 
+  <!-- INBO RBAC fields -->
+  <field name="rbac"  type="boolean" docValues="false" indexed="true"/>
+  <field name="rbac_allowed"  type="string" docValues="false" multiValued="true" indexed="true"/>
+
 </schema>

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -2319,7 +2319,7 @@ public class SearchDAOImpl implements SearchDAO {
     }
 
     @Override
-    @Cacheable("heatmapCache")
+    @Cacheable(value = "heatmapCache", keyGenerator = "dataRoleCacheKeyGenerator")
     public HeatmapDTO getHeatMap(
             String query,
             String[] filterQueries,

--- a/src/main/java/au/org/ala/biocache/dao/SolrIndexDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SolrIndexDAOImpl.java
@@ -44,6 +44,8 @@ import org.gbif.dwc.terms.Term;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;

--- a/src/main/java/au/org/ala/biocache/dao/SolrIndexDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SolrIndexDAOImpl.java
@@ -186,6 +186,12 @@ public class SolrIndexDAOImpl implements IndexDAO {
     @Value("${solr.home:}")
     protected String solrHome;
 
+    @Value("${rbac.enabled:false}")
+    private boolean rbacEnabled;
+
+    @Value("${rbac.rolePrefix:}")
+    private String rolePrefix;
+
     // CoreContainer cc;
     SolrClient solrClient;
     CloseableHttpClient httpClient;
@@ -300,6 +306,10 @@ public class SolrIndexDAOImpl implements IndexDAO {
     @Override
     public QueryResponse query(SolrParams query) throws Exception {
         int retry = 0;
+
+        if (rbacEnabled) {
+            query = addRbacFilter(query);
+        }
 
         QueryResponse qr = null;
         while (retry < maxRetries && qr == null) {
@@ -1230,6 +1240,10 @@ public class SolrIndexDAOImpl implements IndexDAO {
         }
         solrParams.set("qt", qt);
 
+        if (rbacEnabled) {
+            return addRbacFilter(solrParams);
+        }
+
         return solrParams;
     }
 
@@ -1333,5 +1347,33 @@ public class SolrIndexDAOImpl implements IndexDAO {
 
     private String escapeDoubleQuote(String input) {
         return input.replaceAll("\"", "\\\\\"");
+    }
+
+    private ModifiableSolrParams addRbacFilter(SolrParams query) {
+        var newParams = new ModifiableSolrParams(query);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        var roles = "";
+        if (auth != null) {
+            roles = auth.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .filter(role -> role.startsWith(rolePrefix))
+                    .map(role -> role.substring(rolePrefix.length()))
+                    .collect(Collectors.joining(" "));
+            if (!roles.isEmpty()) {
+                newParams.add("fq",
+                        "(*:* NOT dynamicProperties_rbac:*) " +
+                                "OR (dynamicProperties_rbac:true AND dynamicProperties_rbac_allowed:(" + roles + ")) " +
+                                "OR (dynamicProperties_rbac:false AND !dynamicProperties_rbac_allowed:(" + roles + "))"
+                );
+                return newParams;
+            }
+        }
+
+        newParams.add("fq",
+                "(*:* NOT dynamicProperties_rbac:*) OR dynamicProperties_rbac:false"
+        );
+
+        return newParams;
     }
 }

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -48,6 +48,10 @@ import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.support.AbstractMessageSource;
 import org.springframework.core.io.Resource;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestOperations;
 
@@ -1138,6 +1142,12 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
 
             boolean shuttingDown = false;
             boolean doRetry = false;
+
+            // Ensure the Thread creating the download is running in the correct security-context
+            var user = currentDownload.getAlaUser();
+            var authorities = user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(toList());
+            var auth = new PreAuthenticatedAuthenticationToken(user, List.of(), authorities);
+            SecurityContextHolder.getContext().setAuthentication(auth);
 
             try (FileOutputStream fos = FileUtils.openOutputStream(new File(currentDownload.getFileLocation()));) {
                 List<CreateDoiResponse> doiResponseList = null;

--- a/src/main/java/au/org/ala/biocache/service/DownloadService.java
+++ b/src/main/java/au/org/ala/biocache/service/DownloadService.java
@@ -1145,9 +1145,11 @@ public class DownloadService implements ApplicationListener<ContextClosedEvent> 
 
             // Ensure the Thread creating the download is running in the correct security-context
             var user = currentDownload.getAlaUser();
-            var authorities = user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(toList());
-            var auth = new PreAuthenticatedAuthenticationToken(user, List.of(), authorities);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+            if (user != null) {
+                var authorities = user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(toList());
+                var auth = new PreAuthenticatedAuthenticationToken(user, List.of(), authorities);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
 
             try (FileOutputStream fos = FileUtils.openOutputStream(new File(currentDownload.getFileLocation()));) {
                 List<CreateDoiResponse> doiResponseList = null;

--- a/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
+++ b/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @Component("dataRoleCacheKeyGenerator")
 public class DataRoleCacheKeyGenerator implements KeyGenerator {
 
-    @Value("${rbac.enabled}")
+    @Value("${rbac.enabled:false}")
     private boolean rbacEnabled;
 
     @Value("${rbac.rolePrefix:}")

--- a/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
+++ b/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
@@ -1,0 +1,40 @@
+package au.org.ala.biocache.util;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+import java.util.stream.Collectors;
+
+/*
+ Generate a dynamic cache-key bases on the users data roles, as result queries can differ base on user permissions when rbac is enabled.
+ */
+
+@Component("dataRoleCacheKeyGenerator")
+public class DataRoleCacheKeyGenerator implements KeyGenerator {
+
+    @Value("${rbac.rolePrefix:}")
+    private String rolePrefix;
+
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        var roles = "";
+        if (auth != null) {
+            roles = auth.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .filter(role -> role.startsWith(rolePrefix))
+                    .map(role -> role.substring(rolePrefix.length()))
+                    .sorted()
+                    .collect(Collectors.joining("_"));
+        }
+
+        return StringUtils.arrayToDelimitedString(params, "_") + "_"
+                + roles;
+    }
+}

--- a/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
+++ b/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 /*
  Generate a dynamic cache-key based on the users data roles,
  as result queries can differ base on user permissions when rbac is enabled.
+ warning: Does not use the method name (Just like Spring default), so should not be used for a "shared cache"
  */
 
 @Component("dataRoleCacheKeyGenerator")

--- a/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
+++ b/src/main/java/au/org/ala/biocache/util/DataRoleCacheKeyGenerator.java
@@ -12,29 +12,36 @@ import java.lang.reflect.Method;
 import java.util.stream.Collectors;
 
 /*
- Generate a dynamic cache-key bases on the users data roles, as result queries can differ base on user permissions when rbac is enabled.
+ Generate a dynamic cache-key based on the users data roles,
+ as result queries can differ base on user permissions when rbac is enabled.
  */
 
 @Component("dataRoleCacheKeyGenerator")
 public class DataRoleCacheKeyGenerator implements KeyGenerator {
+
+    @Value("${rbac.enabled}")
+    private boolean rbacEnabled;
 
     @Value("${rbac.rolePrefix:}")
     private String rolePrefix;
 
     @Override
     public Object generate(Object target, Method method, Object... params) {
-        var auth = SecurityContextHolder.getContext().getAuthentication();
-        var roles = "";
-        if (auth != null) {
-            roles = auth.getAuthorities().stream()
-                    .map(GrantedAuthority::getAuthority)
-                    .filter(role -> role.startsWith(rolePrefix))
-                    .map(role -> role.substring(rolePrefix.length()))
-                    .sorted()
-                    .collect(Collectors.joining("_"));
+        var cacheKey = StringUtils.arrayToDelimitedString(params, "_");
+
+        if (rbacEnabled) {
+            // Add concatenated data roles to cache-key if auth context provided
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null) {
+                cacheKey += auth.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .filter(role -> role.startsWith(rolePrefix))
+                        .map(role -> role.substring(rolePrefix.length()))
+                        .sorted()
+                        .collect(Collectors.joining("_"));
+            }
         }
 
-        return StringUtils.arrayToDelimitedString(params, "_") + "_"
-                + roles;
+        return cacheKey;
     }
 }

--- a/src/main/java/au/org/ala/biocache/web/DownloadController.java
+++ b/src/main/java/au/org/ala/biocache/web/DownloadController.java
@@ -75,7 +75,7 @@ import static java.util.stream.Collectors.*;
 @Slf4j
 public class DownloadController extends AbstractSecureController {
 
-    final private static Logger logger = Logger.getLogger(ScatterplotController.class);
+    final private static Logger logger = Logger.getLogger(DownloadController.class);
 
     /** Fulltext search DAO */
     @Inject

--- a/src/test/java/au/org/ala/biocache/dao/SolrIndexDAOImplRbacFilterIT.java
+++ b/src/test/java/au/org/ala/biocache/dao/SolrIndexDAOImplRbacFilterIT.java
@@ -1,0 +1,387 @@
+package au.org.ala.biocache.dao;
+
+import au.org.ala.biocache.util.SolrUtils;
+import junit.framework.TestCase;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Integration tests for RBAC (Role-Based Access Control) logic in SolrIndexDAOImpl.
+ * <p>
+ * Tests scenarios:
+ * - rbacEnabled = false: all records are returned as before
+ * - rbacEnabled = true:
+ * - Records without RBAC fields are shown to all users
+ * - Records with dynamicProperties_rbac=true are shown only to users with matching roles
+ * - Records with dynamicProperties_rbac=false are hidden from users with matching roles
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:springTest.xml"})
+@WebAppConfiguration
+@TestPropertySource(locations = "classpath:biocache-test-config.properties")
+public class SolrIndexDAOImplRbacFilterIT extends TestCase {
+
+    static {
+        System.setProperty("biocache.config", System.getProperty("user.dir") + "/src/test/resources/biocache-test-config.properties");
+    }
+
+    private static final String ROLE_PREFIX = "DATA_ROLE_";
+
+    @Autowired
+    SolrIndexDAOImpl solrIndexDAO;
+
+    @BeforeClass
+    public static void setupBeforeClass() throws Exception {
+        SolrUtils.setupIndex();
+        loadRbacTestData();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        // Clear any existing security context before each test
+        SecurityContextHolder.clearContext();
+    }
+
+    @After
+    public void tearDown() {
+        // Clear security context after each test
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void givenRbacDisabledThenAllRecordsReturnedForAnonymousUser() throws Exception {
+        setRbacEnabled(false);
+        setSecurityContext(Collections.emptyList());
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // All 8 RBAC test records should be returned when RBAC is disabled
+        assertEquals(8, response.getResults().size());
+    }
+
+    @Test
+    public void givenRbacDisabledThenAllRecordsReturnedForAuthenticatedUser() throws Exception {
+        setRbacEnabled(false);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // All 8 RBAC test records should be returned when RBAC is disabled
+        assertEquals(8, response.getResults().size());
+    }
+
+    @Test
+    public void givenRbacEnabledThenAnonymousUserSeesOnlyUnrestrictedAndPublicRecords() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(Collections.emptyList());
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // Anonymous user should see:
+        // - 2 records without RBAC fields (rbac-no-restrictions-*)
+        // - 3 records with dynamicProperties_rbac=false (rbac-denied-roleA-1, rbac-denied-roleB-1, rbac-public-1)
+        //   Anonymous users have no roles, so role-specific denials don't apply to them
+        // NOT visible: records with dynamicProperties_rbac=true (require specific role to access)
+        // Total: 5 records
+        assertEquals(5, response.getResults().size());
+
+        // Verify which records are returned
+        List<String> returnedIds = response.getResults().stream()
+                .map(doc -> (String) doc.getFieldValue("id"))
+                .sorted()
+                .toList();
+
+        assertTrue(returnedIds.contains("rbac-no-restrictions-1"));
+        assertTrue(returnedIds.contains("rbac-no-restrictions-2"));
+        assertTrue(returnedIds.contains("rbac-denied-roleA-1"));
+        assertTrue(returnedIds.contains("rbac-denied-roleB-1"));
+        assertTrue(returnedIds.contains("rbac-public-1"));
+
+        // Should NOT see records with dynamicProperties_rbac=true (require specific roles)
+        assertFalse(returnedIds.contains("rbac-allowed-roleA-1"));
+        assertFalse(returnedIds.contains("rbac-allowed-roleA-2"));
+        assertFalse(returnedIds.contains("rbac-allowed-roleB-1"));
+    }
+
+    @Test
+    public void givenRbacEnabledThenDataWithoutRbacFieldsShownToAllUsers() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(Collections.emptyList());
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-no-restrictions-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // Records without RBAC fields should always be visible
+        assertEquals(2, response.getResults().size());
+    }
+
+    @Test
+    public void givenRbacEnabledThenUserWithRoleASeesAllowedRecords() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // User with roleA should see:
+        // - 2 records without RBAC fields (rbac-no-restrictions-*)
+        // - 2 records with dynamicProperties_rbac=true AND allowed=roleA (rbac-allowed-roleA-*)
+        // - 1 record with dynamicProperties_rbac=false AND allowed=roleB (rbac-denied-roleB-1) - not denied to roleA
+        // - 1 record with dynamicProperties_rbac=false and no roles (rbac-public-1)
+        // NOT: rbac-denied-roleA-1 (dynamicProperties_rbac=false AND allowed=roleA)
+        // NOT: rbac-allowed-roleB-1 (dynamicProperties_rbac=true AND allowed=roleB, not roleA)
+        // Total: 6 records
+
+        List<String> returnedIds = response.getResults().stream()
+                .map(doc -> (String) doc.getFieldValue("id"))
+                .sorted()
+                .toList();
+
+        assertEquals(6, response.getResults().size());
+
+        assertTrue(returnedIds.contains("rbac-no-restrictions-1"));
+        assertTrue(returnedIds.contains("rbac-no-restrictions-2"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleA-1"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleA-2"));
+        assertTrue(returnedIds.contains("rbac-denied-roleB-1"));
+        assertTrue(returnedIds.contains("rbac-public-1"));
+
+        // Should NOT contain records denied to roleA
+        assertFalse(returnedIds.contains("rbac-denied-roleA-1"));
+        // Should NOT contain records allowed only to roleB
+        assertFalse(returnedIds.contains("rbac-allowed-roleB-1"));
+    }
+
+    @Test
+    public void givenRbacEnabledThenUserWithRoleADoesNotSeeDeniedRecords() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-denied-roleA-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // User with roleA should NOT see records specifically denied to roleA
+        assertEquals(0, response.getResults().size());
+    }
+
+    @Test
+    public void givenRbacEnabledThenUserWithRoleBSeesAllowedRecords() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleB"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // User with roleB should see:
+        // - 2 records without RBAC fields (rbac-no-restrictions-*)
+        // - 1 record with dynamicProperties_rbac=true AND allowed=roleB (rbac-allowed-roleB-1)
+        // - 1 record with dynamicProperties_rbac=false AND allowed=roleA (rbac-denied-roleA-1) - not denied to roleB
+        // - 1 record with dynamicProperties_rbac=false and no roles (rbac-public-1)
+        // NOT: rbac-denied-roleB-1 (dynamicProperties_rbac=false AND allowed=roleB)
+        // NOT: rbac-allowed-roleA-* (dynamicProperties_rbac=true AND allowed=roleA, not roleB)
+        // Total: 5 records
+
+        List<String> returnedIds = response.getResults().stream()
+                .map(doc -> (String) doc.getFieldValue("id"))
+                .sorted()
+                .toList();
+
+        assertEquals(5, response.getResults().size());
+
+        assertTrue(returnedIds.contains("rbac-no-restrictions-1"));
+        assertTrue(returnedIds.contains("rbac-no-restrictions-2"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleB-1"));
+        assertTrue(returnedIds.contains("rbac-denied-roleA-1"));
+        assertTrue(returnedIds.contains("rbac-public-1"));
+
+        // Should NOT contain records denied to roleB
+        assertFalse(returnedIds.contains("rbac-denied-roleB-1"));
+        // Should NOT contain records allowed only to roleA
+        assertFalse(returnedIds.contains("rbac-allowed-roleA-1"));
+        assertFalse(returnedIds.contains("rbac-allowed-roleA-2"));
+    }
+
+    @Test
+    public void givenRbacEnabledThenUserWithMultipleRolesSeesAllAllowedRecords() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA", ROLE_PREFIX + "roleB"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // User with both roleA and roleB should see:
+        // - 2 records without RBAC fields (rbac-no-restrictions-*)
+        // - 2 records allowed to roleA (rbac-allowed-roleA-*)
+        // - 1 record allowed to roleB (rbac-allowed-roleB-1)
+        // - 1 record with dynamicProperties_rbac=false and no roles (rbac-public-1)
+        // NOT: rbac-denied-roleA-1 (denied to roleA)
+        // NOT: rbac-denied-roleB-1 (denied to roleB)
+        // Total: 6 records
+
+        List<String> returnedIds = response.getResults().stream()
+                .map(doc -> (String) doc.getFieldValue("id"))
+                .sorted()
+                .toList();
+
+        assertEquals(6, response.getResults().size());
+
+        assertTrue(returnedIds.contains("rbac-no-restrictions-1"));
+        assertTrue(returnedIds.contains("rbac-no-restrictions-2"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleA-1"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleA-2"));
+        assertTrue(returnedIds.contains("rbac-allowed-roleB-1"));
+        assertTrue(returnedIds.contains("rbac-public-1"));
+
+        // Should NOT contain denied records
+        assertFalse(returnedIds.contains("rbac-denied-roleA-1"));
+        assertFalse(returnedIds.contains("rbac-denied-roleB-1"));
+    }
+
+    @Test
+    public void givenRbacEnabledThenUserWithNonMatchingRolePrefixTreatedAsAnonymous() throws Exception {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        // User has roles but not with the expected prefix
+        setSecurityContext(List.of("OTHER_PREFIX_roleA"));
+
+        SolrQuery query = new SolrQuery();
+        query.setQuery("id:rbac-*");
+        query.setRows(100);
+
+        QueryResponse response = solrIndexDAO.query(query);
+
+        // User with non-matching role prefix should be treated as anonymous
+        // Should see same records as anonymous user: 5 records
+        assertEquals(5, response.getResults().size());
+    }
+
+    private static final String RBAC_TEST_DATA = """
+            id,scientificName,vernacularName,dataResourceUid,year,decimalLatitude,decimalLongitude,dynamicProperties_rbac,dynamicProperties_rbac_allowed
+            rbac-no-restrictions-1,Circus assimilis,Spotted Harrier,dr0,2020,-32.75,151.08333,,
+            rbac-no-restrictions-2,Circus assimilis,Spotted Harrier,dr0,2020,-33.75,152.08333,,
+            rbac-allowed-roleA-1,Circus assimilis,Spotted Harrier,dr0,2021,-34.75,153.08333,true,roleA
+            rbac-allowed-roleA-2,Circus assimilis,Spotted Harrier,dr0,2021,-35.75,154.08333,true,roleA
+            rbac-allowed-roleB-1,Circus assimilis,Spotted Harrier,dr0,2021,-36.75,155.08333,true,roleB
+            rbac-denied-roleA-1,Circus assimilis,Spotted Harrier,dr0,2022,-37.75,156.08333,false,roleA
+            rbac-denied-roleB-1,Circus assimilis,Spotted Harrier,dr0,2022,-38.75,157.08333,false,roleB
+            rbac-public-1,Circus assimilis,Spotted Harrier,dr0,2023,-39.75,158.08333,false,
+            """;
+
+    private static void loadRbacTestData() throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new InMemoryCsvResource(RBAC_TEST_DATA, "rbac-test-data.csv"));
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        String serverUrl = "http://localhost:8983/solr/biocache/update?commit=true";
+
+        RestTemplate restTemplate = new RestTemplate();
+        var response = restTemplate.postForEntity(serverUrl, requestEntity, String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    /**
+     * In-memory resource that mimics a file for multipart uploads.
+     */
+    private static class InMemoryCsvResource extends org.springframework.core.io.ByteArrayResource {
+        private final String filename;
+
+        public InMemoryCsvResource(String content, String filename) {
+            super(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            this.filename = filename;
+        }
+
+        @Override
+        public String getFilename() {
+            return filename;
+        }
+    }
+
+    private void setRbacEnabled(boolean enabled) {
+        ReflectionTestUtils.setField(solrIndexDAO, "rbacEnabled", enabled);
+    }
+
+    private void setRolePrefix(String prefix) {
+        ReflectionTestUtils.setField(solrIndexDAO, "rolePrefix", prefix);
+    }
+
+    private void setSecurityContext(List<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            SecurityContextHolder.clearContext();
+            return;
+        }
+        List<SimpleGrantedAuthority> authorities = roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken("testuser", "password", authorities);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}
+
+
+
+
+

--- a/src/test/java/au/org/ala/biocache/service/DownloadServiceTest.java
+++ b/src/test/java/au/org/ala/biocache/service/DownloadServiceTest.java
@@ -1014,6 +1014,163 @@ public class DownloadServiceTest {
         verify(testService.emailService, times(0)).sendEmail(any(), any(), any());
     }
 
+    /**
+     * Test that when an offline download is performed with an authenticated user with roles,
+     * the user context (including roles) is properly propagated to the search layer.
+     */
+    @Test
+    public final void testOfflineDownloadUserContextPropagation() throws Exception {
+
+        testService = createDownloadServiceForOfflineTest();
+
+        mockStatic(FileUtils.class);
+        given(FileUtils.readFileToString(any(), eq(StandardCharsets.UTF_8))).willReturn("");
+        given(FileUtils.openOutputStream(any())).willCallRealMethod();
+        given(FileUtils.openOutputStream(any(), anyBoolean())).willCallRealMethod();
+
+        // Capture the DownloadDetailsDTO passed to searchDAO to verify user context
+        ArgumentCaptor<DownloadDetailsDTO> ddCaptor = ArgumentCaptor.forClass(DownloadDetailsDTO.class);
+        when(testService.searchDAO.writeResultsFromIndexToStream(any(), any(), any(), ddCaptor.capture(), anyBoolean(), any()))
+                .thenReturn(new DownloadHeaders(new String[] {}, new String[] {}, new String[] {}, new String[] {}, new String[] {}, new String[] {}));
+        when(testService.dataQualityService.convertDataQualityParameters(any(), any())).thenAnswer(returnsFirstArg());
+
+        testService.support = "support@ala.org.au";
+        testService.myDownloadsUrl = "https://dev.ala.org.au/myDownloads";
+        testService.biocacheDownloadUrl = "http://dev.ala.org.au/biocache-download";
+        testService.biocacheDownloadEmailTemplate = "/tmp/download-email.html";
+        testService.biocacheDownloadReadmeTemplate = "/tmp/readme.txt";
+
+        testService.init();
+        Thread.sleep(500);
+
+        DownloadRequestDTO requestParams = new DownloadRequestDTO();
+        requestParams.setDisplayString("[all records]");
+
+        // Create a user with specific roles for RBAC
+        AlaUserProfile userWithRoles = createTestUserWithRoles("TestUserWithRoles", "testuser@example.org",
+                new HashSet<>(Arrays.asList("ROLE_USER", "ROLE_DATA_ACCESS")));
+
+        DownloadDetailsDTO dd = new DownloadDetailsDTO(requestParams, userWithRoles, "::1", "", DownloadType.RECORDS_INDEX);
+        testService.add(dd);
+        Thread.sleep(5000);
+
+        // Verify email was sent
+        verify(testService.emailService, times(1)).sendEmail(any(), any(), any());
+
+        // Verify user context was passed to the search layer
+        DownloadDetailsDTO capturedDD = ddCaptor.getValue();
+        assertThat("User should be passed to search layer", capturedDD.getAlaUser(), notNullValue());
+        assertThat("User ID should match", capturedDD.getAlaUser().getUserId(), equalTo("TestUserWithRoles"));
+        assertThat("User roles should be passed", capturedDD.getAlaUser().getRoles(),
+                containsInAnyOrder("ROLE_USER", "ROLE_DATA_ACCESS"));
+    }
+
+    /**
+     * Test that offline download works correctly when user has no roles (anonymous download).
+     */
+    @Test
+    public final void testOfflineDownloadWithNullUser() throws Exception {
+
+        testService = createDownloadServiceForOfflineTest();
+
+        mockStatic(FileUtils.class);
+        given(FileUtils.readFileToString(any(), eq(StandardCharsets.UTF_8))).willReturn("");
+        given(FileUtils.openOutputStream(any())).willCallRealMethod();
+        given(FileUtils.openOutputStream(any(), anyBoolean())).willCallRealMethod();
+
+        when(testService.searchDAO.writeResultsFromIndexToStream(any(), any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(new DownloadHeaders(new String[] {}, new String[] {}, new String[] {}, new String[] {}, new String[] {}, new String[] {}));
+        when(testService.dataQualityService.convertDataQualityParameters(any(), any())).thenAnswer(returnsFirstArg());
+
+        testService.support = "support@ala.org.au";
+        testService.myDownloadsUrl = "https://dev.ala.org.au/myDownloads";
+        testService.biocacheDownloadUrl = "http://dev.ala.org.au/biocache-download";
+        testService.biocacheDownloadEmailTemplate = "/tmp/download-email.html";
+        testService.biocacheDownloadReadmeTemplate = "/tmp/readme.txt";
+
+        testService.init();
+        Thread.sleep(500);
+
+        DownloadRequestDTO requestParams = new DownloadRequestDTO();
+        requestParams.setDisplayString("[all records]");
+
+        // Null user (anonymous download)
+        DownloadDetailsDTO dd = new DownloadDetailsDTO(requestParams, null, "::1", "", DownloadType.RECORDS_INDEX);
+        testService.add(dd);
+        Thread.sleep(5000);
+
+        // Should complete without errors (no NPE from null user)
+        verify(testService.emailService, times(1)).sendEmail(any(), any(), any());
+    }
+
+    /**
+     * Helper method to create a test user with specified roles.
+     */
+    private AlaUserProfile createTestUserWithRoles(String userId, String email, Set<String> roles) {
+        return new AlaUserProfile() {
+            @Override
+            public String getId() { return userId; }
+            @Override
+            public void setId(String id) { }
+            @Override
+            public String getTypedId() { return null; }
+            @Override
+            public String getUsername() { return userId; }
+            @Override
+            public Object getAttribute(String name) { return null; }
+            @Override
+            public Map<String, Object> getAttributes() { return null; }
+            @Override
+            public boolean containsAttribute(String name) { return false; }
+            @Override
+            public void addAttribute(String key, Object value) { }
+            @Override
+            public void removeAttribute(String key) { }
+            @Override
+            public void addAuthenticationAttribute(String key, Object value) { }
+            @Override
+            public void removeAuthenticationAttribute(String key) { }
+            @Override
+            public void addRole(String role) { }
+            @Override
+            public void addRoles(Collection<String> rolesArg) { }
+            @Override
+            public Set<String> getRoles() { return roles; }
+            @Override
+            public void addPermission(String permission) { }
+            @Override
+            public void addPermissions(Collection<String> permissions) { }
+            @Override
+            public Set<String> getPermissions() { return Collections.emptySet(); }
+            @Override
+            public boolean isRemembered() { return false; }
+            @Override
+            public void setRemembered(boolean rme) { }
+            @Override
+            public String getClientName() { return null; }
+            @Override
+            public void setClientName(String clientName) { }
+            @Override
+            public String getLinkedId() { return null; }
+            @Override
+            public void setLinkedId(String linkedId) { }
+            @Override
+            public boolean isExpired() { return false; }
+            @Override
+            public Principal asPrincipal() { return null; }
+            @Override
+            public String getName() { return userId; }
+            @Override
+            public String getUserId() { return userId; }
+            @Override
+            public String getEmail() { return email; }
+            @Override
+            public String getGivenName() { return "Test"; }
+            @Override
+            public String getFamilyName() { return "User"; }
+        };
+    }
+
     @Test
     public final void testDataQualityResourceTemplate() throws Exception {
         List<QualityFilterDTO> qualityFilters = new ArrayList<>();

--- a/src/test/java/au/org/ala/biocache/util/DataRoleCacheKeyGeneratorTest.java
+++ b/src/test/java/au/org/ala/biocache/util/DataRoleCacheKeyGeneratorTest.java
@@ -1,0 +1,182 @@
+package au.org.ala.biocache.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataRoleCacheKeyGeneratorTest {
+
+    private static final String ROLE_PREFIX = "DATA_ROLE_";
+
+    private DataRoleCacheKeyGenerator keyGenerator;
+
+    @Before
+    public void setUp() {
+        keyGenerator = new DataRoleCacheKeyGenerator();
+        SecurityContextHolder.clearContext();
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void givenRbacDisabledThenOnlyParams() {
+        setRbacEnabled(false);
+        setRolePrefix(ROLE_PREFIX);
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        assertEquals("param1_param2", cacheKey);
+    }
+
+    @Test
+    public void givenRbacDisabledAndAuthenticationThenOnlyParams() {
+        setRbacEnabled(false);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        assertEquals("param1_param2", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndNoAuthenticationThenOnlyParams() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        // No security context set
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        assertEquals("param1_param2", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndSingleRoleThenIncludesRoleInKey() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        assertEquals("param1_param2roleA", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndMultipleRolesThenIncludesSortedRolesInKey() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        // Roles added in non-sorted order
+        setSecurityContext(List.of(ROLE_PREFIX + "roleC", ROLE_PREFIX + "roleA", ROLE_PREFIX + "roleB"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        // Roles should be sorted alphabetically
+        assertEquals("param1_param2roleA_roleB_roleC", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndMixedRolesThenOnlyIncludesMatchingPrefixRoles() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        // Mix of matching and non-matching role prefixes
+        setSecurityContext(List.of(
+                ROLE_PREFIX + "roleA",
+                "OTHER_PREFIX_roleX",
+                ROLE_PREFIX + "roleB",
+                "ROLE_ADMIN"
+        ));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        // Only roles with DATA_ROLE_ prefix should be included
+        assertEquals("param1_param2roleA_roleB", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndNoMatchingRolesThenOnlyParams() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        // User has roles but none with the expected prefix
+        setSecurityContext(List.of("ROLE_USER", "ROLE_ADMIN"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1", "param2");
+
+        assertEquals("param1_param2", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndEmptyParamsThenOnlyRoles() {
+        setRbacEnabled(true);
+        setRolePrefix(ROLE_PREFIX);
+        setSecurityContext(List.of(ROLE_PREFIX + "roleA"));
+
+        Object cacheKey = keyGenerator.generate(this, null);
+
+        assertEquals("roleA", cacheKey);
+    }
+
+    @Test
+    public void givenRbacDisabledAndEmptyParamsThenEmptyString() {
+        setRbacEnabled(false);
+        setRolePrefix(ROLE_PREFIX);
+
+        Object cacheKey = keyGenerator.generate(this, null);
+
+        assertEquals("", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndEmptyRolePrefixThenIncludesAllRoles() {
+        setRbacEnabled(true);
+        setRolePrefix("");
+        setSecurityContext(List.of("roleA", "ROLE_ADMIN", "roleB"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1");
+
+        // All roles should be included and sorted
+        assertEquals("param1ROLE_ADMIN_roleA_roleB", cacheKey);
+    }
+
+    @Test
+    public void givenRbacEnabledAndCustomRolePrefixThenFiltersCorrectly() {
+        setRbacEnabled(true);
+        setRolePrefix("CUSTOM_");
+        setSecurityContext(List.of("CUSTOM_role1", "DATA_ROLE_roleA", "CUSTOM_role2"));
+
+        Object cacheKey = keyGenerator.generate(this, null, "param1");
+
+        assertEquals("param1role1_role2", cacheKey);
+    }
+
+    private void setRbacEnabled(boolean enabled) {
+        ReflectionTestUtils.setField(keyGenerator, "rbacEnabled", enabled);
+    }
+
+    private void setRolePrefix(String prefix) {
+        ReflectionTestUtils.setField(keyGenerator, "rolePrefix", prefix);
+    }
+
+    private void setSecurityContext(List<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            SecurityContextHolder.clearContext();
+            return;
+        }
+        List<SimpleGrantedAuthority> authorities = roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken("testuser", "password", authorities);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}


### PR DESCRIPTION
This change adds **optional** support for role based access control.
By default it is disabled and should have no impact on current installations.

The ideas is as outlined here: https://github.com/inbo/vlaams-biodiversiteitsportaal/wiki/Sensitive-data#add-allowed-roles-to-the-solr-index

It simply adds an additional _fq_ to all solr queries that uses the current user's  roles to always show the correct version of the data. This allows us to provide both low and high-resolution versions of the same data.
Access to higher resolution data is determined by the presence of certain data-roles and some dynamicProperties in the data. 

It is running and tested in the Flemish portal.
But we have heard other people might be interested as well.
If there is any interest, the simple ternary boolean logic in the rbac fq can be modified to be more generic to cover additional cases too. (e.g. the data-provider managed sensitive FQs in the UK)

Just to be clear, the main benefit here, over the existing support for sensitive data, is that people can actually use the sensitive data in the portal, just like non-sensitive data. Not just have it available when downloading.

Any and all suggestions / etc. are of course welcome!