### PR TITLE
Add flimit and fcontains support

### DIFF
--- a/config/biocache-config.properties
+++ b/config/biocache-config.properties
@@ -183,6 +183,14 @@ facets.defaultmax=0
 # default &facet value (true|false). Clients must always set &facet=true when facets are required and this default is false.
 facet.default=true
 
+# maximum allowed value for the flimit (facet limit) parameter in user requests.
+# set to -1 to disable the limit (default). Requests exceeding this value get a 400 response.
+flimit.max=-1
+
+# maximum allowed value for the pageSize parameter in user requests.
+# set to -1 to disable the limit (default). Requests exceeding this value get a 400 response.
+pageSize.max=-1
+
 # autocomplete related caches
 autocomplete.species.images.enabled=true
 autocomplete.species.counts.enabled=true

--- a/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
+++ b/src/main/java/au/org/ala/biocache/dao/SearchDAOImpl.java
@@ -216,6 +216,23 @@ public class SearchDAOImpl implements SearchDAO {
     @Value("${wms.legendMaxItems:30}")
     private int wmslegendMaxItems;
 
+    /**
+     * Maximum allowed value for the flimit (facet limit) parameter in user
+     * requests.
+     * Set to -1 to disable the limit. When enabled, requests exceeding this value
+     * will receive a 400 Bad Request response.
+     */
+    @Value("${flimit.max:-1}")
+    private int flimitMax;
+
+    /**
+     * Maximum allowed value for the pageSize parameter in user requests.
+     * Set to -1 to disable the limit. When enabled, requests exceeding this value
+     * will receive a 400 Bad Request response.
+     */
+    @Value("${pageSize.max:-1}")
+    private int pageSizeMax;
+
     @Value("${download.offline.max.size:100000000}")
     public Integer dowloadOfflineMaxSize = 100000000;
 
@@ -1295,6 +1312,32 @@ public class SearchDAOImpl implements SearchDAO {
     }
 
     /**
+     * Cap flimit at a max if configured and log warning when flimit requested exceeds max
+     * @param flimit the request facet limit
+     * @return The capped flimit
+     */
+    private int capFlimit(int flimit) {
+        if (flimitMax >= 0 && (flimit < 0 || flimit > flimitMax)) {
+            logger.warn("Requested facet limit exceeds maximum " + flimit + ", capping at " + flimitMax);
+            return flimitMax;
+        }
+        return flimit;
+    }
+
+    /**
+     * Cap pageSize at a max if configured and log warning when pageSize requested exceeds max
+     * @param pageSize the requested page size
+     * @return The capped flimit
+     */
+    private int capPageSize(int pageSize) {
+        if (pageSizeMax >= 0 && (pageSize < 0 || pageSize > pageSizeMax)) {
+            logger.warn("Requested page size exceeds maximum " + pageSize + ", capping at " + pageSizeMax);
+            return pageSizeMax;
+        }
+        return pageSize;
+    }
+
+    /**
      * Helper method to create SolrQuery object and add facet settings
      *
      * @return solrQuery the SolrQuery
@@ -1343,17 +1386,21 @@ public class SearchDAOImpl implements SearchDAO {
             }
 
             solrQuery.setFacetMinCount(1);
-            solrQuery.setFacetLimit(searchParams.getFlimit());
-            //include this so that the default fsort is still obeyed.
+            solrQuery.setFacetLimit(capFlimit(searchParams.getFlimit()));
+            // include this so that the default fsort is still obeyed.
             String fsort = StringUtils.isEmpty(searchParams.getFsort()) ? "count" : searchParams.getFsort();
             solrQuery.setFacetSort(fsort);
             if (searchParams.getFoffset() > 0)
                 solrQuery.add("facet.offset", Integer.toString(searchParams.getFoffset()));
             if (StringUtils.isNotEmpty(searchParams.getFprefix()))
                 solrQuery.add("facet.prefix", searchParams.getFprefix());
+            if (StringUtils.isNotEmpty(searchParams.getFcontains())) {
+                solrQuery.add("facet.contains", searchParams.getFcontains());
+                solrQuery.add("facet.contains.ignoreCase", "true");
+            }
         }
 
-        solrQuery.setRows(searchParams.getPageSize());
+        solrQuery.setRows(capPageSize(searchParams.getPageSize()));
         solrQuery.setStart(searchParams.getStart());
         if (StringUtils.isNotEmpty(searchParams.getDir()) && StringUtils.isNotEmpty(searchParams.getSort())) {
             solrQuery.setSort(searchParams.getSort(), SolrQuery.ORDER.valueOf(searchParams.getDir()));

--- a/src/main/java/au/org/ala/biocache/dto/SearchRequestDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/SearchRequestDTO.java
@@ -73,6 +73,8 @@ public class SearchRequestDTO {
     protected Integer foffset = 0;
     /** The prefix to limit facet values*/
     protected String fprefix = "";
+    /** Limits facet values to those containing this substring */
+    protected String fcontains = "";
     protected Integer pageSize = 10;
     protected String sort = "";
     protected String dir = "asc";
@@ -154,6 +156,8 @@ public class SearchRequestDTO {
             req.append("&foffset=").append(foffset);
         if(!"".equals(fprefix))
             req.append("&fprefix=").append(fprefix);
+        if(!"".equals(fcontains))
+            req.append("&fcontains=").append(fcontains);
 
         if (!Strings.isNullOrEmpty(qualityProfile)) {
             req.append("&qualityProfile=").append(conditionalEncode(qualityProfile, encodeParams));
@@ -501,6 +505,18 @@ public class SearchRequestDTO {
 	public void setFprefix(String fprefix) {
 		this.fprefix = fprefix;
 	}
+	/**
+	 * @return the fcontains
+	 */
+	public String getFcontains() {
+		return fcontains;
+	}
+	/**
+	 * @param fcontains the fcontains to set
+	 */
+	public void setFcontains(String fcontains) {
+		this.fcontains = fcontains;
+	}
 
     public Boolean getIncludeMultivalues() {
         return includeMultivalues;
@@ -568,6 +584,7 @@ public class SearchRequestDTO {
                 Objects.equals(fsort, that.fsort) &&
                 Objects.equals(foffset, that.foffset) &&
                 Objects.equals(fprefix, that.fprefix) &&
+                Objects.equals(fcontains, that.fcontains) &&
                 Objects.equals(pageSize, that.pageSize) &&
                 Objects.equals(sort, that.sort) &&
                 Objects.equals(dir, that.dir) &&
@@ -580,7 +597,7 @@ public class SearchRequestDTO {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(formattedQuery, q, fl, start, facetsMax, flimit, fsort, foffset, fprefix, pageSize, sort, dir, displayString, qc, facet, qualityProfile, disableAllQualityFilters, disableQualityFilter);
+        int result = Objects.hash(formattedQuery, q, fl, start, facetsMax, flimit, fsort, foffset, fprefix, fcontains, pageSize, sort, dir, displayString, qc, facet, qualityProfile, disableAllQualityFilters, disableQualityFilter);
         result = 31 * result + Arrays.hashCode(fq);
         result = 31 * result + Arrays.hashCode(facets);
         return result;

--- a/src/main/java/au/org/ala/biocache/dto/SpatialSearchRequestParams.java
+++ b/src/main/java/au/org/ala/biocache/dto/SpatialSearchRequestParams.java
@@ -66,6 +66,9 @@ public class SpatialSearchRequestParams {
     @Parameter(name="fprefix", description = "The prefix to limit facet values")
     protected String fprefix ="";
 
+    @Parameter(name="fcontains", description = "Limits facet values to those containing this substring")
+    protected String fcontains ="";
+
     @Parameter(name="start", description = "Paging start index")
     protected Integer start;
 

--- a/src/test/java/au/org/ala/biocache/dao/SolrIndexDAOImplIT.java
+++ b/src/test/java/au/org/ala/biocache/dao/SolrIndexDAOImplIT.java
@@ -1,6 +1,9 @@
 package au.org.ala.biocache.dao;
 
+import au.org.ala.biocache.dto.FacetResultDTO;
 import au.org.ala.biocache.dto.FieldResultDTO;
+import au.org.ala.biocache.dto.SearchResultDTO;
+import au.org.ala.biocache.dto.SpatialSearchRequestDTO;
 import au.org.ala.biocache.stream.EndemicFacet;
 import au.org.ala.biocache.stream.ProcessInterface;
 import au.org.ala.biocache.util.QueryFormatUtils;
@@ -20,6 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,6 +45,9 @@ public class SolrIndexDAOImplIT extends TestCase {
 
     @Autowired
     SolrIndexDAOImpl solrIndexDAO;
+
+    @Autowired
+    SearchDAOImpl searchDAO;
 
     @Autowired
     QueryFormatUtils queryFormatUtils;
@@ -188,6 +195,156 @@ public class SolrIndexDAOImplIT extends TestCase {
         assertEquals(null, initialValue);
         assertEquals(true, trueValue);
         assertEquals(false, falseValue);
+    }
+
+    @Test
+    public void flimitMaxCapsResults() throws Exception {
+        // Set flimitMax to 5 so that facet requests are capped
+        ReflectionTestUtils.setField(searchDAO, "flimitMax", 5);
+        try {
+            SpatialSearchRequestDTO params = new SpatialSearchRequestDTO();
+            params.setQ("*:*");
+            params.setFacet(true);
+            params.setFacets(new String[]{"year"});
+            params.setFlimit(100);
+            params.setPageSize(0);
+
+            SearchResultDTO result = searchDAO.findByFulltextSpatialQuery(params, false, null);
+
+            assertNotNull(result.getFacetResults());
+            assertFalse(result.getFacetResults().isEmpty());
+            FacetResultDTO yearFacet = result.getFacetResults().get(0);
+            assertTrue(
+                    "Facet result size should be capped at flimitMax=5, but got " + yearFacet.getFieldResult().size(),
+                    yearFacet.getFieldResult().size() <= 5
+            );
+        } finally {
+            // Restore default (disabled)
+            ReflectionTestUtils.setField(searchDAO, "flimitMax", -1);
+        }
+    }
+
+    @Test
+    public void flimitMaxDisabledReturnsRequestedAmount() throws Exception {
+        // With flimitMax=-1 (disabled), the full requested flimit should be returned
+        ReflectionTestUtils.setField(searchDAO, "flimitMax", -1);
+
+        SpatialSearchRequestDTO params = new SpatialSearchRequestDTO();
+        params.setQ("*:*");
+        params.setFacet(true);
+        params.setFacets(new String[]{"year"});
+        params.setFlimit(50);
+        params.setPageSize(0);
+
+        SearchResultDTO result = searchDAO.findByFulltextSpatialQuery(params, false, null);
+
+        assertNotNull(result.getFacetResults());
+        assertFalse(result.getFacetResults().isEmpty());
+        FacetResultDTO yearFacet = result.getFacetResults().get(0);
+        // The test index has many years; with no cap, all 50 (or fewer if index has fewer) should come back
+        assertTrue(
+                "Expected up to 50 facet values without a cap, but got " + yearFacet.getFieldResult().size(),
+                yearFacet.getFieldResult().size() > 5
+        );
+    }
+
+    @Test
+    public void pageSizeMaxCapsResults() throws Exception {
+        // Set pageSizeMax to 5 so that row requests are capped
+        ReflectionTestUtils.setField(searchDAO, "pageSizeMax", 5);
+        try {
+            SpatialSearchRequestDTO params = new SpatialSearchRequestDTO();
+            params.setQ("*:*");
+            params.setFacet(false);
+            params.setPageSize(1000);
+
+            SearchResultDTO result = searchDAO.findByFulltextSpatialQuery(params, false, null);
+
+            assertTrue(
+                    "Result count should be capped at pageSizeMax=5, but got " + result.getOccurrences().size(),
+                    result.getOccurrences().size() <= 5
+            );
+        } finally {
+            // Restore default (disabled)
+            ReflectionTestUtils.setField(searchDAO, "pageSizeMax", -1);
+        }
+    }
+
+    @Test
+    public void pageSizeMaxDisabledReturnsRequestedAmount() throws Exception {
+        // With pageSizeMax=-1 (disabled), the full requested pageSize should be honoured
+        ReflectionTestUtils.setField(searchDAO, "pageSizeMax", -1);
+
+        SpatialSearchRequestDTO params = new SpatialSearchRequestDTO();
+        params.setQ("*:*");
+        params.setFacet(false);
+        params.setPageSize(50);
+
+        SearchResultDTO result = searchDAO.findByFulltextSpatialQuery(params, false, null);
+
+        assertTrue(
+                "Expected 50 results without a cap, but got " + result.getOccurrences().size(),
+                result.getOccurrences().size() > 5
+        );
+    }
+
+    @Test
+    public void fcontainsFiltersToMatchingFacetValues() throws Exception {
+        // kingdom has values "Animalia" (981 records) and "Plantae" (5 records).
+        // fcontains="alia" should return only the "Animalia" facet value.
+        SpatialSearchRequestDTO params = new SpatialSearchRequestDTO();
+        params.setQ("*:*");
+        params.setFacet(true);
+        params.setFacets(new String[]{"kingdom"});
+        params.setFlimit(100);
+        params.setFcontains("alia");
+        params.setPageSize(0);
+
+        SearchResultDTO result = searchDAO.findByFulltextSpatialQuery(params, false, null);
+
+        assertNotNull(result.getFacetResults());
+        assertFalse("Expected facet results for kingdom field", result.getFacetResults().isEmpty());
+        FacetResultDTO facet = result.getFacetResults().get(0);
+        assertNotNull(facet.getFieldResult());
+        assertFalse("Expected at least one kingdom value containing 'alia'", facet.getFieldResult().isEmpty());
+        for (FieldResultDTO fieldResult : facet.getFieldResult()) {
+            assertTrue(
+                    "Facet value '" + fieldResult.getFieldValue() + "' should contain 'alia'",
+                    fieldResult.getFieldValue().toLowerCase().contains("alia")
+            );
+        }
+    }
+
+    @Test
+    public void fcontainsEmptyReturnsAllFacetValues() throws Exception {
+        // kingdom has "Animalia" and "Plantae". With fcontains="alia" only "Animalia" is returned;
+        // with fcontains="" (disabled) both values are returned.
+        SpatialSearchRequestDTO paramsWithFilter = new SpatialSearchRequestDTO();
+        paramsWithFilter.setQ("*:*");
+        paramsWithFilter.setFacet(true);
+        paramsWithFilter.setFacets(new String[]{"kingdom"});
+        paramsWithFilter.setFlimit(100);
+        paramsWithFilter.setFcontains("alia");
+        paramsWithFilter.setPageSize(0);
+
+        SpatialSearchRequestDTO paramsNoFilter = new SpatialSearchRequestDTO();
+        paramsNoFilter.setQ("*:*");
+        paramsNoFilter.setFacet(true);
+        paramsNoFilter.setFacets(new String[]{"kingdom"});
+        paramsNoFilter.setFlimit(100);
+        paramsNoFilter.setFcontains("");
+        paramsNoFilter.setPageSize(0);
+
+        SearchResultDTO filteredResult = searchDAO.findByFulltextSpatialQuery(paramsWithFilter, false, null);
+        SearchResultDTO unfilteredResult = searchDAO.findByFulltextSpatialQuery(paramsNoFilter, false, null);
+
+        int filteredCount = filteredResult.getFacetResults().get(0).getFieldResult().size();
+        int unfilteredCount = unfilteredResult.getFacetResults().get(0).getFieldResult().size();
+
+        assertTrue(
+                "Unfiltered facet results (" + unfilteredCount + ") should be greater than filtered results (" + filteredCount + ")",
+                unfilteredCount > filteredCount
+        );
     }
 
     @Test


### PR DESCRIPTION
Probably related to: https://github.com/AtlasOfLivingAustralia/biocache-service/issues/982

But mostly did it to hopefully prevent malicious users from bringing down the entire portal by simply querying a high-cardinality field with an unlimited flimit: https://github.com/AtlasOfLivingAustralia/biocache-hubs/issues/648

Added the fcontains while I was at it to allow easier use of filters. (will open a PR with the necessary changes for biocache-hubs soon). But here's a screenshot:
<img width="849" height="543" alt="image" src="https://github.com/user-attachments/assets/724a556c-3393-46e9-bbee-31cc3d63b3f4" />
