### PR TITLE
Update WMSController.java

### DIFF
--- a/src/main/java/au/org/ala/biocache/dto/SearchRequestDTO.java
+++ b/src/main/java/au/org/ala/biocache/dto/SearchRequestDTO.java
@@ -137,7 +137,7 @@ public class SearchRequestDTO {
         req.append("&pageSize=").append(pageSize);
         req.append("&sort=").append(sort);
         req.append("&dir=").append(dir);
-        req.append("&qc=").append(qc);
+        req.append("&qc=").append(conditionalEncode(qc, encodeParams));
         if (facets != null && facets.length > 0 && isFacet) {
             for (String f : facets) {
                 req.append("&facets=").append(conditionalEncode(f, encodeParams));

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -70,8 +70,6 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1797,12 +1795,7 @@ public class WMSController extends AbstractSecureController {
             transformBBox(transformFrom4326, extents, bbox4326, bboxSRS);
             bboxString = bboxSRS[0] + "," + bboxSRS[1] + "," + bboxSRS[2] + "," + bboxSRS[3];
         }
-        
-       // Force standard decimal notation to prevent scientific notation (e.g. E7) from breaking upstream WMS parsers.
-       // Uses English locale to guarantee '.' as the decimal separator across various system environments.
-        java.text.DecimalFormat df = new java.text.DecimalFormat("0.00000000", java.text.DecimalFormatSymbols.getInstance(java.util.Locale.ENGLISH));
-        bboxString = df.format(bboxSRS[0]) + "," + df.format(bboxSRS[1]) + "," + df.format(bboxSRS[2]) + "," + df.format(bboxSRS[3]);
-        
+               
         int width = (int) ((dpi / 25.4) * widthMm);
         int height = (int) Math.round(width * ((bboxSRS[3] - bboxSRS[1]) / (bboxSRS[2] - bboxSRS[0])));
 

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -70,6 +70,8 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1788,14 +1790,19 @@ public class WMSController extends AbstractSecureController {
         CoordinateOperation transformTo4326 = new DefaultCoordinateOperationFactory().createOperation(sourceCRS, targetCRS);
         CoordinateOperation transformFrom4326 = new DefaultCoordinateOperationFactory().createOperation(targetCRS, sourceCRS);
         double[] bbox4326 = new double[4];     // extents in EPSG:4326
-        double[] bboxSRS = new double[4];      //extents in target SRS
+        double[] bboxSRS = new double[4];      // extents in target SRS
         if (bboxString != null) {
             transformBBox(transformTo4326, bboxString, bboxSRS, bbox4326);
         } else {
             transformBBox(transformFrom4326, extents, bbox4326, bboxSRS);
             bboxString = bboxSRS[0] + "," + bboxSRS[1] + "," + bboxSRS[2] + "," + bboxSRS[3];
         }
-
+        
+       // Force standard decimal notation to prevent scientific notation (e.g. E7) from breaking upstream WMS parsers.
+       // Uses English locale to guarantee '.' as the decimal separator across various system environments.
+        java.text.DecimalFormat df = new java.text.DecimalFormat("0.00000000", java.text.DecimalFormatSymbols.getInstance(java.util.Locale.ENGLISH));
+        bboxString = df.format(bboxSRS[0]) + "," + df.format(bboxSRS[1]) + "," + df.format(bboxSRS[2]) + "," + df.format(bboxSRS[3]);
+        
         int width = (int) ((dpi / 25.4) * widthMm);
         int height = (int) Math.round(width * ((bboxSRS[3] - bboxSRS[1]) / (bboxSRS[2] - bboxSRS[0])));
 
@@ -1838,7 +1845,10 @@ public class WMSController extends AbstractSecureController {
 
         // add query parameters
         speciesAddress += serialisedQueryParameters;
-
+        
+        // Sanitize literal spaces
+        speciesAddress = speciesAddress.replace(" ", "%20");
+        
         URL speciesURL = new URL(speciesAddress);
         BufferedImage speciesImage = ImageIO.read(speciesURL);
 

--- a/src/main/java/au/org/ala/biocache/web/WMSController.java
+++ b/src/main/java/au/org/ala/biocache/web/WMSController.java
@@ -1838,10 +1838,7 @@ public class WMSController extends AbstractSecureController {
 
         // add query parameters
         speciesAddress += serialisedQueryParameters;
-        
-        // Sanitize literal spaces
-        speciesAddress = speciesAddress.replace(" ", "%20");
-        
+               
         URL speciesURL = new URL(speciesAddress);
         BufferedImage speciesImage = ImageIO.read(speciesURL);
 


### PR DESCRIPTION
Closes #995
Fixed an HTTP 400 Bad Request failure inside the WMS generatePublicationMap.

The qc filter statement retained raw space characters. Now a final safety sanitize step changing " " to "%20" solves this.

A sample error where you can spot the problem:
Caused by: java.io.IOException: Server returned HTTP response code: 400 for URL: https://registos-ws.gbif.pt/ogc/wms/reflect?ENV=color%3A0D00FB%3Bname%3Acircle%3Bsize%3A8%3Bopacity%3A0.7&SRS=EPSG:3857&BBOX=-2.0585408961537383E7,-8766409.899970291,2.5907872115090776E7,1.4715045189235853E7&WIDTH=1771&HEIGHT=894&OUTLINE=true&OUTLINECOLOUR=0x000000&q=*%3A*&start=0&pageSize=10&sort=score&dir=asc&qc=data_hub_uid:dh0 -_nest_parent_:*&fl=country%2Craw_countryCode%2Creferences%2CscientificName%2Cyear%2Cpoint-0.01%2Clat_long%2CdecimalLatitude%2CcatalogNumber%2CbasisOfRecord%2CstateInvasive%2Craw_scientificName%2Craw_vernacularName%2CtaxonConceptID%2CsoundIDs%2Cpoint-0.1%2Cid%2Cassertions%2CspatiallyValid%2Corder%2CtaxonRankID%2CdataResourceName%2CrecordNumber%2Craw_basisOfRecord%2CstateProvince%2CdecimalLongitude%2CcollectionCode%2CspeciesID%2CoccurrenceID%2Csensitive%2Cpoint-1%2Cpoint-0.0001%2Clicense%2Cmonth%2CdataResourceUid%2Cgenus%2CdataHubUid%2Clft%2Csubspecies%2CimageIDs%2CcountryInvasive%2CeventDate%2CimageID%2Craw_typeStatus%2CcoordinateUncertaintyInMeters%2CtaxonRank%2CgenusID%2CidentificationVerificationStatus%2CcollectionName%2CvernacularName%2ClocationRemarks%2ChasUserAssertions%2CinstitutionCode%2Crights%2Cclass%2CcollectionUid%2CcountryConservation%2Crgt%2Cnames_and_lsid%2Cpoint-0.001%2CtypeStatus%2Ckingdom%2CdataProviderUid%2CrecordedBy%2Cmultimedia%2Cphylum%2CinstitutionUid%2Cspecies%2CdataProviderName%2CinstitutionName%2CdataHubName%2CsubspeciesID%2CeventDateEnd%2CoccurrenceRemarks%2CspeciesGroup%2CstateConservation%2Cfamily%2CvideoIDs%2CuserAssertions&facet=true 

